### PR TITLE
Add Tenant Command Improvements

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -311,7 +311,7 @@ func CreateDeploymentWithTenants(tenants []*StorageGroupTenant, sg *StorageGroup
 		envName := fmt.Sprintf("%s-env", sgTenant.ShortName)
 		volumeMounts := []v1.VolumeMount{}
 		tenantContainer := v1.Container{
-			Name:            fmt.Sprintf("%s-minio-%s", sgTenant.Tenant.Name, hostNum),
+			Name:            fmt.Sprintf("%s-minio-%s", sgTenant.Tenant.ShortName, hostNum),
 			Image:           "minio/minio:edge",
 			ImagePullPolicy: "IfNotPresent",
 			Args: []string{
@@ -353,8 +353,8 @@ func CreateDeploymentWithTenants(tenants []*StorageGroupTenant, sg *StorageGroup
 		}
 		//volumes that will be used by this sgTenant
 		for vi := 1; vi <= MaxNumberDiskPerNode; vi++ {
-			vname := fmt.Sprintf("%s-pv-%d", sgTenant.Tenant.Name, vi)
-			volumenSource := v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: fmt.Sprintf("/mnt/disk%d/%s", vi, sgTenant.Tenant.Name)}}
+			vname := fmt.Sprintf("%s-pv-%d", sgTenant.Tenant.ShortName, vi)
+			volumenSource := v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: fmt.Sprintf("/mnt/disk%d/%s", vi, sgTenant.Tenant.ShortName)}}
 			hostPathVolume := v1.Volume{Name: vname, VolumeSource: volumenSource}
 			mainPodSpec.Volumes = append(mainPodSpec.Volumes, hostPathVolume)
 
@@ -453,7 +453,7 @@ func CreateTenantFolderInDiskAndWait(tenant *Tenant, sg *StorageGroup, hostNumbe
 		var backoff int32 = 0
 		var ttlJob int32 = 60
 
-		jobName := fmt.Sprintf("provision-sg-%d-host-%d-%s-job", sg.Num, hostNumber, tenant.Name)
+		jobName := fmt.Sprintf("provision-sg-%d-host-%d-%s-job", sg.Num, hostNumber, tenant.ShortName)
 		job := batchv1.Job{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Job",

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -85,7 +85,7 @@ This is benign and can be fixed with the following steps,
   ./m3 tenant add company-name
 ```
 
-If the company name is not url-friend a short name will be generated, but it can also be specified.
+If the company name is not url-friendly a short name will be generated, but it can also be specified.
 
 ```shell
   ./m3 tenant add "Commpany® Inc." --short_name company-inc

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -82,7 +82,13 @@ This is benign and can be fixed with the following steps,
 
 ## Adding a tenant
 ```shell
-  ./m3 tenant add -n company-name --short_name comp-name
+  ./m3 tenant add company-name
+```
+
+If the company name is not url-friend a short name will be generated, but it can also be specified.
+
+```shell
+  ./m3 tenant add "Commpany® Inc." --short_name company-inc
 ```
 
 ## Accessing the tenant MinIO service via browser UI


### PR DESCRIPTION
Some improvements to the `tenant add` command and also some bug fixes that showed up.
 sample usage:
-      `m3 tenant add tenant-1`
-      `m3 tenant add --name tenant-1`
-      `m3 tenant add "Company® Inc." --short_name company-1`
-      `m3 tenant add --name "Company® Inc." --short_name company-1`