### PR TITLE
use a cryptographic PRNG when generating credentials

### DIFF
--- a/cluster/tenants.go
+++ b/cluster/tenants.go
@@ -66,8 +66,8 @@ func AddTenant(name string, shortName string) error {
 
 	// Generate the Tenant's Access/Secret key and operator
 	tenantConfig := TenantConfiguration{
-		AccessKey: RandomKeyWithLength(16),
-		SecretKey: RandomKeyWithLength(32)}
+		AccessKey: RandomCharString(16),
+		SecretKey: RandomCharString(32)}
 
 	// Create a store for the tenant's configuration
 	err = CreateTenantSecrets(tenantResult.Tenant, &tenantConfig)

--- a/cluster/utils_test.go
+++ b/cluster/utils_test.go
@@ -1,0 +1,25 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cluster
+
+import "testing"
+
+func TestAlphabetLen(t *testing.T) {
+	if 256%len(letters) != 0 {
+		t.Fatalf("The alphabet size %d must be divisor of 256", len(letters))
+	}
+}


### PR DESCRIPTION
This commit replaces the implementation of generating
random access/secret keys. The previous implementation
used math/rand and a scheme from
https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
to generate "random" access/secret keys.

This is not correct since it uses math/rand for generating
access credentials. For any kind of secret information
(cryptographic keys a.s.o) a (cryptographically) secure PRNG
must be used.