### PR TITLE
Create user ui credentials

### DIFF
--- a/cluster/client-admin.go
+++ b/cluster/client-admin.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package portal
+package cluster
 
 import (
 	"crypto/tls"

--- a/cluster/client-s3-trace_v4.go
+++ b/cluster/client-s3-trace_v4.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package portal
+package cluster
 
 import (
 	"net/http"

--- a/cluster/client.go
+++ b/cluster/client.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package portal
+package cluster
 
 import (
 	"github.com/minio/minio-go/v6"

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package portal
+package cluster
 
 // hostConfig configuration of a host.
 type hostConfigV9 struct {

--- a/cluster/connections.go
+++ b/cluster/connections.go
@@ -1,0 +1,178 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cluster
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+
+	// postgres driver for database/sql
+	_ "github.com/lib/pq"
+)
+
+type Singleton struct {
+	Db         *sql.DB
+	tenantsCnx map[string]*sql.DB
+}
+
+var instance *Singleton
+var once sync.Once
+
+// Returns a Singleton instance that keeps the connections to the Database
+func GetInstance() *Singleton {
+	once.Do(func() {
+		// Wait for the DB connection
+		ctx := context.Background()
+
+		// Get the m3 Database configuration
+		config := GetM3DbConfig()
+		db := <-ConnectToDb(ctx, config)
+
+		//build connections cache
+		cnxCache := make(map[string]*sql.DB)
+
+		instance = &Singleton{
+			Db:         db,
+			tenantsCnx: cnxCache,
+		}
+	})
+	return instance
+}
+
+// DbConfig holds the configuration to connect to a database
+type DbConfig struct {
+	// Hostname
+	Host string
+	// Port
+	Port string
+	// User
+	User string
+	// Password
+	Pwd string
+	// Database Name
+	Name string
+	// Whether SSL is enabled on the connection or not
+	Ssl bool
+	// Schema name
+	SchemaName string
+}
+
+// GetM3DbConfig returns a `DbConfig` object with the values for the database by either reading them from the environment or
+// defaulting them to a known value.
+func GetM3DbConfig() *DbConfig {
+	dbHost := "localhost"
+	if os.Getenv("DB_HOSTNAME") != "" {
+		dbHost = os.Getenv("DB_HOSTNAME")
+	}
+
+	dbPort := "5432"
+	if os.Getenv("DB_PORT") != "" {
+		dbPort = os.Getenv("DB_PORT")
+	}
+
+	dbUser := "postgres"
+	if os.Getenv("DB_USER") != "" {
+		dbUser = os.Getenv("DB_USER")
+	}
+
+	dbPass := "m3meansmkube"
+	if os.Getenv("DB_PASSWORD") != "" {
+		dbPass = os.Getenv("DB_PASSWORD")
+	}
+	dbSsl := false
+	if os.Getenv("DB_SSL") != "" {
+		if os.Getenv("DB_SSL") == "true" {
+			dbSsl = true
+		}
+	}
+
+	dbName := "m3"
+	if os.Getenv("DB_NAME") != "" {
+		dbName = os.Getenv("DB_NAME")
+	}
+	return &DbConfig{
+		Host: dbHost,
+		Port: dbPort,
+		User: dbUser,
+		Pwd:  dbPass,
+		Name: dbName,
+		Ssl:  dbSsl,
+	}
+}
+
+// Creates a connection to the DB and returns it
+func ConnectToDb(ctx context.Context, config *DbConfig) chan *sql.DB {
+	ch := make(chan *sql.DB)
+	go func() {
+		defer close(ch)
+		select {
+		case <-ctx.Done():
+		default:
+			dbStr := "host=" + config.Host + " port=" + config.Port + " user=" + config.User
+			if config.Pwd != "" {
+				dbStr = dbStr + " password=" + config.Pwd
+			}
+
+			dbStr = dbStr + " dbname=" + config.Name
+			if config.Ssl {
+				dbStr = dbStr + " sslmode=enable"
+			} else {
+				dbStr = dbStr + " sslmode=disable"
+			}
+			// if a schema is sepcified, set it as the search path
+			if config.SchemaName != "" {
+				dbStr = fmt.Sprintf("%s search_path=%s", dbStr, config.SchemaName)
+			}
+
+			db, err := sql.Open("postgres", dbStr)
+			if err != nil {
+				log.Fatal(err)
+			}
+			ch <- db
+		}
+	}()
+	return ch
+}
+
+// GetTenantDB returns a database connection to the tenant being accessed, if the connection has been established
+// then it's returned from a local cache, else it's created, cached and returned.
+func (s *Singleton) GetTenantDB(tenantName string) *sql.DB {
+	// if we find the connection in the cache, return it
+	if db, ok := s.tenantsCnx[tenantName]; ok {
+		//do something here
+		return db
+	}
+	// if we reach this point, there was no connection in cache, connect and return the connection
+	ctx := context.Background()
+	// Get the tenant DB configuration
+	config := GetTenantDBConfig(tenantName)
+	tenantDbCnx := <-ConnectToDb(ctx, config)
+	s.tenantsCnx[tenantName] = tenantDbCnx
+	return s.tenantsCnx[tenantName]
+}
+
+func GetTenantDBConfig(tenantName string) *DbConfig {
+	// right now all tenants live on the same server as m3, but on a different DB
+	config := GetM3DbConfig()
+	config.Name = "tenants"
+	config.SchemaName = tenantName
+	return config
+}

--- a/cluster/const.go
+++ b/cluster/const.go
@@ -17,6 +17,7 @@
 package cluster
 
 const (
+	Version        = `0.1.0`
 	minioAccessKey = "MINIO_ACCESS_KEY"
 	minioSecretKey = "MINIO_SECRET_KEY"
 	accessKey      = "ACCESS_KEY"

--- a/cluster/const.go
+++ b/cluster/const.go
@@ -19,4 +19,6 @@ package cluster
 const (
 	minioAccessKey = "MINIO_ACCESS_KEY"
 	minioSecretKey = "MINIO_SECRET_KEY"
+	accessKey      = "ACCESS_KEY"
+	secretKey      = "SECRET_KEY"
 )

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -35,7 +35,7 @@ type Context struct {
 	WhoAmI string
 }
 
-// MainTx returns a transaction agains the Main DB, if none has been started, it starts one
+// MainTx returns a transaction against the Main DB, if none has been started, it starts one
 func (c *Context) MainTx() (*sql.Tx, error) {
 	if c.mainTx == nil {
 		db := GetInstance().Db
@@ -57,7 +57,7 @@ func (c *Context) TenantDB() *sql.DB {
 	return c.tenantDB
 }
 
-// TenantTx returns a transaction agains the Tenant DB, if none has been started, it starts one
+// TenantTx returns a transaction against the Tenant DB, if none has been started, it starts one
 func (c *Context) TenantTx() (*sql.Tx, error) {
 	if c.mainTx == nil {
 		db := c.TenantDB()

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -27,11 +27,13 @@ import (
 type Context struct {
 	*sql.Tx
 	Main context.Context
+	// a user identifier of who is starting the context
+	WhoAmI string
 }
 
 // Creates a new `Context` given an initial transaction and `context.Context`
 // to control timeouts and cancellations.
 func NewContext(ctx context.Context, tx *sql.Tx) *Context {
-	c := &Context{Tx: tx, Main: ctx}
+	c := &Context{Tx: tx, Main: ctx, WhoAmI: "command line"}
 	return c
 }

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -35,6 +35,7 @@ type Context struct {
 	WhoAmI string
 }
 
+// MainTx returns a transaction agains the Main DB, if none has been started, it starts one
 func (c *Context) MainTx() (*sql.Tx, error) {
 	if c.mainTx == nil {
 		db := GetInstance().Db
@@ -47,6 +48,7 @@ func (c *Context) MainTx() (*sql.Tx, error) {
 	return c.mainTx, nil
 }
 
+// TenantDB returns a configured DB connection for the Tenant DB
 func (c *Context) TenantDB() *sql.DB {
 	if c.tenantDB == nil {
 		db := GetInstance().GetTenantDB(c.TenantShortName)
@@ -55,6 +57,7 @@ func (c *Context) TenantDB() *sql.DB {
 	return c.tenantDB
 }
 
+// TenantTx returns a transaction agains the Tenant DB, if none has been started, it starts one
 func (c *Context) TenantTx() (*sql.Tx, error) {
 	if c.mainTx == nil {
 		db := c.TenantDB()
@@ -67,6 +70,7 @@ func (c *Context) TenantTx() (*sql.Tx, error) {
 	return c.tenantTx, nil
 }
 
+// Commit commits the any transaction that was started on this context
 func (c *Context) Commit() error {
 	// commit tenant schema tx
 	if c.tenantTx != nil {
@@ -74,6 +78,8 @@ func (c *Context) Commit() error {
 		if err != nil {
 			return err
 		}
+		// restart the txn
+		c.tenantTx = nil
 	}
 	// commit main schema tx
 	if c.mainTx != nil {
@@ -81,6 +87,8 @@ func (c *Context) Commit() error {
 		if err != nil {
 			return err
 		}
+		// restart the txn
+		c.mainTx = nil
 	}
 	return nil
 }
@@ -92,6 +100,8 @@ func (c *Context) Rollback() error {
 		if err != nil {
 			return err
 		}
+		// restart the txn
+		c.tenantTx = nil
 	}
 	// rollback main schema tx
 	if c.mainTx != nil {
@@ -99,6 +109,8 @@ func (c *Context) Rollback() error {
 		if err != nil {
 			return err
 		}
+		// restart the txn
+		c.mainTx = nil
 	}
 	return nil
 }

--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -31,7 +31,7 @@ type UserUICredentials struct {
 	SecretKey string
 }
 
-// createUserCredentials creates some random access/secret key pair and then stores them on k8s, if successfull
+// createUserCredentials creates some random access/secret key pair and then stores them on k8s, if successful
 // it will create a MinIO User and attach `readwrite` policy, if successful, it will insert this credential to the
 // tenant DB
 func createUserCredentials(ctx *Context, tenantShortName string, userdID uuid.UUID) error {

--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -17,7 +17,6 @@
 package cluster
 
 import (
-	"errors"
 	"fmt"
 	"log"
 
@@ -91,32 +90,4 @@ func storeUserUICredentialsSecret(tenantShortName string, userID *uuid.UUID, cre
 	}
 	_, err = clientset.CoreV1().Secrets(tenantShortName).Create(&secret)
 	return err
-}
-
-// getUserUICredentials returns the UI access/secret key pair for a given user for a given tenant
-func getUserUICredentials(tenant *Tenant, userId *uuid.UUID) (*UserUICredentials, error) {
-	clientset, err := k8sClient()
-	if err != nil {
-		return nil, err
-	}
-	// the user secret is behind it's identifier
-	secretsName := fmt.Sprintf("ui-%s", userId.String())
-	mainSecret, err := clientset.CoreV1().Secrets(tenant.ShortName).Get(secretsName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	creds := UserUICredentials{}
-	// Make sure we have the data we need
-	if val, ok := mainSecret.Data[accessKey]; ok {
-		creds.AccessKey = string(val)
-	} else {
-		return nil, errors.New("secret has not ui access key")
-	}
-	if val, ok := mainSecret.Data[accessKey]; ok {
-		creds.SecretKey = string(val)
-	} else {
-		return nil, errors.New("secret has not ui secret key")
-	}
-	// Build configuration
-	return &creds, nil
 }

--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -32,7 +32,7 @@ type UserUICredentials struct {
 	SecretKey string
 }
 
-func createUserCredentials(ctx *Context, tenantShortName string, userdId uuid.UUID) error {
+func createUserCredentials(ctx *Context, tenantShortName string, userdID uuid.UUID) error {
 
 	userUICredentials := UserUICredentials{
 		AccessKey: RandomCharString(16),
@@ -40,7 +40,7 @@ func createUserCredentials(ctx *Context, tenantShortName string, userdId uuid.UU
 
 	// Attempt to store in k8s, if it works, store in DB
 
-	err := storeUserUICredentialsSecret(tenantShortName, &userdId, &userUICredentials)
+	err := storeUserUICredentialsSecret(tenantShortName, &userdID, &userUICredentials)
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -59,7 +59,7 @@ func createUserCredentials(ctx *Context, tenantShortName string, userdId uuid.UU
 	}
 	defer stmt.Close()
 	// Execute query
-	_, err = ctx.Tx.Exec(query, userUICredentials.AccessKey, userdId, true, ctx.WhoAmI)
+	_, err = ctx.Tx.Exec(query, userUICredentials.AccessKey, userdID, true, ctx.WhoAmI)
 	if err != nil {
 		ctx.Tx.Rollback()
 		return err
@@ -67,7 +67,7 @@ func createUserCredentials(ctx *Context, tenantShortName string, userdId uuid.UU
 	return nil
 }
 
-func storeUserUICredentialsSecret(tenantShortName string, userId *uuid.UUID, credentials *UserUICredentials) error {
+func storeUserUICredentialsSecret(tenantShortName string, userID *uuid.UUID, credentials *UserUICredentials) error {
 	// creates the clientset
 	clientset, err := k8sClient()
 
@@ -76,7 +76,7 @@ func storeUserUICredentialsSecret(tenantShortName string, userId *uuid.UUID, cre
 	}
 
 	// store the crendential exclusively for this user, this way there can only be 1 credentials per use
-	secretsName := fmt.Sprintf("ui-%s", userId.String())
+	secretsName := fmt.Sprintf("ui-%s", userID.String())
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretsName,
@@ -93,6 +93,7 @@ func storeUserUICredentialsSecret(tenantShortName string, userId *uuid.UUID, cre
 	return err
 }
 
+// getUserUICredentials returns the UI access/secret key pair for a given user for a given tenant
 func getUserUICredentials(tenant *Tenant, userId *uuid.UUID) (*UserUICredentials, error) {
 	clientset, err := k8sClient()
 	if err != nil {

--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -31,6 +31,9 @@ type UserUICredentials struct {
 	SecretKey string
 }
 
+// createUserCredentials creates some random access/secret key pair and then stores them on k8s, if successfull
+// it will create a MinIO User and attach `readwrite` policy, if successful, it will insert this credential to the
+// tenant DB
 func createUserCredentials(ctx *Context, tenantShortName string, userdID uuid.UUID) error {
 
 	userUICredentials := UserUICredentials{
@@ -94,6 +97,7 @@ func createUserCredentials(ctx *Context, tenantShortName string, userdID uuid.UU
 	return nil
 }
 
+// storeUserUICredentialsSecret saves some UserUICredentials to a k8s secret on the tenant namespace
 func storeUserUICredentialsSecret(tenantShortName string, userID *uuid.UUID, credentials *UserUICredentials) error {
 	// creates the clientset
 	clientset, err := k8sClient()

--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -17,7 +17,6 @@
 package cluster
 
 import (
-	"errors"
 	"fmt"
 	"log"
 

--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -1,0 +1,121 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+type UserUICredentials struct {
+	AccessKey string
+	SecretKey string
+}
+
+func createUserCredentials(ctx *Context, tenantShortName string, userdId uuid.UUID) error {
+
+	userUICredentials := UserUICredentials{
+		AccessKey: RandomCharString(16),
+		SecretKey: RandomCharString(32)}
+
+	// Attempt to store in k8s, if it works, store in DB
+
+	err := storeUserUICredentialsSecret(tenantShortName, &userdId, &userUICredentials)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	query := `
+		INSERT INTO
+				credentials ("access_key","user_id","ui_credential","created_by")
+			  VALUES
+				($1,$2,$3,$4)`
+	stmt, err := ctx.Tx.Prepare(query)
+	if err != nil {
+		ctx.Tx.Rollback()
+		log.Fatal(err)
+		return err
+	}
+	defer stmt.Close()
+	// Execute query
+	_, err = ctx.Tx.Exec(query, userUICredentials.AccessKey, userdId, true, ctx.WhoAmI)
+	if err != nil {
+		ctx.Tx.Rollback()
+		return err
+	}
+	return nil
+}
+
+func storeUserUICredentialsSecret(tenantShortName string, userId *uuid.UUID, credentials *UserUICredentials) error {
+	// creates the clientset
+	clientset, err := k8sClient()
+
+	if err != nil {
+		return err
+	}
+
+	// store the crendential exclusively for this user, this way there can only be 1 credentials per use
+	secretsName := fmt.Sprintf("ui-%s", userId.String())
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretsName,
+			Labels: map[string]string{
+				"app": tenantShortName,
+			},
+		},
+		Data: map[string][]byte{
+			accessKey: []byte(credentials.AccessKey),
+			secretKey: []byte(credentials.SecretKey),
+		},
+	}
+	_, err = clientset.CoreV1().Secrets(tenantShortName).Create(&secret)
+	return err
+}
+
+func getUserUICredentials(tenant *Tenant, userId *uuid.UUID) (*UserUICredentials, error) {
+	clientset, err := k8sClient()
+	if err != nil {
+		return nil, err
+	}
+	// the user secret is behind it's identifier
+	secretsName := fmt.Sprintf("ui-%s", userId.String())
+	mainSecret, err := clientset.CoreV1().Secrets(tenant.ShortName).Get(secretsName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	creds := UserUICredentials{}
+	// Make sure we have the data we need
+	if val, ok := mainSecret.Data[accessKey]; ok {
+		creds.AccessKey = string(val)
+	} else {
+		return nil, errors.New("secret has not ui access key")
+	}
+	if val, ok := mainSecret.Data[accessKey]; ok {
+		creds.SecretKey = string(val)
+	} else {
+		return nil, errors.New("secret has not ui secret key")
+	}
+	// Build configuration
+	return &creds, nil
+}

--- a/cluster/minio-tenant.go
+++ b/cluster/minio-tenant.go
@@ -30,7 +30,7 @@ func mkTenantMinioContainer(sgTenant *StorageGroupTenant, hostNum string) (v1.Co
 	volumeMounts := []v1.VolumeMount{}
 	tenantContainer := v1.Container{
 		Name:            fmt.Sprintf("%s-minio-%s", sgTenant.Tenant.ShortName, hostNum),
-		Image:           "minio/minio:edge",
+		Image:           "minio/minio:latest",
 		ImagePullPolicy: "IfNotPresent",
 		Args: []string{
 			"server",

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -18,7 +18,7 @@ package cluster
 
 func addMinioUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string, secretKey string) error {
 	// get an admin with operator keys
-	adminClient, pErr := NewAdminClient(sgt.Address(), tenantConf.AccessKey, tenantConf.SecretKey)
+	adminClient, pErr := NewAdminClient(sgt.HTTPAddress(false), tenantConf.AccessKey, tenantConf.SecretKey)
 	if pErr != nil {
 		return pErr.Cause
 	}
@@ -32,7 +32,7 @@ func addMinioUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, acce
 
 func addMinioCannedPolicyToUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string, policy string) error {
 	// get an admin with operator keys
-	adminClient, pErr := NewAdminClient(sgt.Address(), tenantConf.AccessKey, tenantConf.SecretKey)
+	adminClient, pErr := NewAdminClient(sgt.HTTPAddress(false), tenantConf.AccessKey, tenantConf.SecretKey)
 	if pErr != nil {
 		return pErr.Cause
 	}

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -1,0 +1,51 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cluster
+
+import "fmt"
+
+func addMinioUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string, secretKey string) error {
+	// Build tenant address
+	tenantAddress := fmt.Sprintf("%s:%d", sgt.ServiceName, sgt.Port)
+	// get an admin with operator keys
+	adminClient, pErr := NewAdminClient(tenantAddress, tenantConf.AccessKey, tenantConf.SecretKey)
+	if pErr != nil {
+		return pErr.Cause
+	}
+	// Add the user
+	err := adminClient.AddUser(accessKey, secretKey)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func addMinioCannedPolicyToUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string, policy string) error {
+	// Build tenant address
+	tenantAddress := fmt.Sprintf("%s:%d", sgt.ServiceName, sgt.Port)
+	// get an admin with operator keys
+	adminClient, pErr := NewAdminClient(tenantAddress, tenantConf.AccessKey, tenantConf.SecretKey)
+	if pErr != nil {
+		return pErr.Cause
+	}
+	// Add the canned policy
+	err := adminClient.AddCannedPolicy(accessKey, policy)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -16,13 +16,9 @@
 
 package cluster
 
-import "fmt"
-
 func addMinioUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string, secretKey string) error {
-	// Build tenant address
-	tenantAddress := fmt.Sprintf("%s:%d", sgt.ServiceName, sgt.Port)
 	// get an admin with operator keys
-	adminClient, pErr := NewAdminClient(tenantAddress, tenantConf.AccessKey, tenantConf.SecretKey)
+	adminClient, pErr := NewAdminClient(sgt.Address(), tenantConf.AccessKey, tenantConf.SecretKey)
 	if pErr != nil {
 		return pErr.Cause
 	}
@@ -35,10 +31,8 @@ func addMinioUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, acce
 }
 
 func addMinioCannedPolicyToUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string, policy string) error {
-	// Build tenant address
-	tenantAddress := fmt.Sprintf("%s:%d", sgt.ServiceName, sgt.Port)
 	// get an admin with operator keys
-	adminClient, pErr := NewAdminClient(tenantAddress, tenantConf.AccessKey, tenantConf.SecretKey)
+	adminClient, pErr := NewAdminClient(sgt.Address(), tenantConf.AccessKey, tenantConf.SecretKey)
 	if pErr != nil {
 		return pErr.Cause
 	}

--- a/cluster/sessions.go
+++ b/cluster/sessions.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
 	"os"
 	"sync"
@@ -136,6 +137,10 @@ func ConnectToDb(ctx context.Context, config *DbConfig) chan *sql.DB {
 			} else {
 				dbStr = dbStr + " sslmode=disable"
 			}
+			// if a schema is sepcified, set it as the search path
+			if config.SchemaName != "" {
+				dbStr = fmt.Sprintf("%s search_path=%s", dbStr, config.SchemaName)
+			}
 
 			db, err := sql.Open("postgres", dbStr)
 			if err != nil {
@@ -150,8 +155,6 @@ func ConnectToDb(ctx context.Context, config *DbConfig) chan *sql.DB {
 // GetTenantDB returns a database connection to the tenant being accessed, if the connection has been established
 // then it's returned from a local cache, else it's created, cached and returned.
 func (s *Singleton) GetTenantDB(tenantName string) *sql.DB {
-	// Right now all tenants share a single connection
-	tenantName = "tenants"
 	// if we find the connection in the cache, return it
 	if db, ok := s.tenantsCnx[tenantName]; ok {
 		//do something here

--- a/cluster/sessions.go
+++ b/cluster/sessions.go
@@ -17,162 +17,53 @@
 package cluster
 
 import (
-	"context"
-	"database/sql"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
-	"log"
-	"os"
-	"sync"
+	"io"
+	"time"
 
-	// postgres driver for database/sql
-	_ "github.com/lib/pq"
+	uuid "github.com/satori/go.uuid"
 )
 
-type Singleton struct {
-	Db         *sql.DB
-	tenantsCnx map[string]*sql.DB
+func CreateSession(ctx *Context, userID uuid.UUID, tenantID uuid.UUID) (*string, error) {
+	// Set query parameters
+	// Insert a new session with random string as id
+	sessionID, err := GetRandString(32, "sha256")
+	if err != nil {
+		return nil, err
+	}
+
+	query :=
+		`INSERT INTO
+				m3.provisioning.sessions ("id","user_id", "tenant_id", "occurred_at")
+			  VALUES
+				($1,$2,$3,$4)`
+	tx, err := ctx.MainTx()
+	if err != nil {
+		return nil, err
+	}
+	// Execute Query
+	_, err = tx.Exec(query, sessionID, userID, tenantID, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	return &sessionID, nil
 }
 
-var instance *Singleton
-var once sync.Once
-
-// Returns a Singleton instance that keeps the connections to the Database
-func GetInstance() *Singleton {
-	once.Do(func() {
-		// Wait for the DB connection
-		ctx := context.Background()
-
-		// Get the m3 Database configuration
-		config := GetM3DbConfig()
-		db := <-ConnectToDb(ctx, config)
-
-		//build connections cache
-		cnxCache := make(map[string]*sql.DB)
-
-		instance = &Singleton{
-			Db:         db,
-			tenantsCnx: cnxCache,
-		}
-	})
-	return instance
-}
-
-// DbConfig holds the configuration to connect to a database
-type DbConfig struct {
-	// Hostname
-	Host string
-	// Port
-	Port string
-	// User
-	User string
-	// Password
-	Pwd string
-	// Database Name
-	Name string
-	// Whether SSL is enabled on the connection or not
-	Ssl bool
-	// Schema name
-	SchemaName string
-}
-
-// GetM3DbConfig returns a `DbConfig` object with the values for the database by either reading them from the environment or
-// defaulting them to a known value.
-func GetM3DbConfig() *DbConfig {
-	dbHost := "localhost"
-	if os.Getenv("DB_HOSTNAME") != "" {
-		dbHost = os.Getenv("DB_HOSTNAME")
+// GetRandString generates a random string with the defined size length
+func GetRandString(size int, method string) (string, error) {
+	rb := make([]byte, size)
+	if _, err := io.ReadFull(rand.Reader, rb); err != nil {
+		return "", err
 	}
 
-	dbPort := "5432"
-	if os.Getenv("DB_PORT") != "" {
-		dbPort = os.Getenv("DB_PORT")
+	randStr := base64.URLEncoding.EncodeToString(rb)
+	if method == "sha256" {
+		h := sha256.New()
+		h.Write([]byte(randStr))
+		randStr = fmt.Sprintf("%x", h.Sum(nil))
 	}
-
-	dbUser := "postgres"
-	if os.Getenv("DB_USER") != "" {
-		dbUser = os.Getenv("DB_USER")
-	}
-
-	dbPass := "m3meansmkube"
-	if os.Getenv("DB_PASSWORD") != "" {
-		dbPass = os.Getenv("DB_PASSWORD")
-	}
-	dbSsl := false
-	if os.Getenv("DB_SSL") != "" {
-		if os.Getenv("DB_SSL") == "true" {
-			dbSsl = true
-		}
-	}
-
-	dbName := "m3"
-	if os.Getenv("DB_NAME") != "" {
-		dbName = os.Getenv("DB_NAME")
-	}
-	return &DbConfig{
-		Host: dbHost,
-		Port: dbPort,
-		User: dbUser,
-		Pwd:  dbPass,
-		Name: dbName,
-		Ssl:  dbSsl,
-	}
-}
-
-// Creates a connection to the DB and returns it
-func ConnectToDb(ctx context.Context, config *DbConfig) chan *sql.DB {
-	ch := make(chan *sql.DB)
-	go func() {
-		defer close(ch)
-		select {
-		case <-ctx.Done():
-		default:
-			dbStr := "host=" + config.Host + " port=" + config.Port + " user=" + config.User
-			if config.Pwd != "" {
-				dbStr = dbStr + " password=" + config.Pwd
-			}
-
-			dbStr = dbStr + " dbname=" + config.Name
-			if config.Ssl {
-				dbStr = dbStr + " sslmode=enable"
-			} else {
-				dbStr = dbStr + " sslmode=disable"
-			}
-			// if a schema is sepcified, set it as the search path
-			if config.SchemaName != "" {
-				dbStr = fmt.Sprintf("%s search_path=%s", dbStr, config.SchemaName)
-			}
-
-			db, err := sql.Open("postgres", dbStr)
-			if err != nil {
-				log.Fatal(err)
-			}
-			ch <- db
-		}
-	}()
-	return ch
-}
-
-// GetTenantDB returns a database connection to the tenant being accessed, if the connection has been established
-// then it's returned from a local cache, else it's created, cached and returned.
-func (s *Singleton) GetTenantDB(tenantName string) *sql.DB {
-	// if we find the connection in the cache, return it
-	if db, ok := s.tenantsCnx[tenantName]; ok {
-		//do something here
-		return db
-	}
-	// if we reach this point, there was no connection in cache, connect and return the connection
-	ctx := context.Background()
-	// Get the tenant DB configuration
-	config := GetTenantDBConfig(tenantName)
-	tenantDbCnx := <-ConnectToDb(ctx, config)
-	s.tenantsCnx[tenantName] = tenantDbCnx
-	return s.tenantsCnx[tenantName]
-}
-
-func GetTenantDBConfig(tenantName string) *DbConfig {
-	// right now all tenants live on the same server as m3, but on a different DB
-	config := GetM3DbConfig()
-	config.Name = "tenants"
-	config.SchemaName = tenantName
-	return config
+	return randStr, nil
 }

--- a/cluster/storage-cluster.go
+++ b/cluster/storage-cluster.go
@@ -120,8 +120,8 @@ func SelectSGWithSpace(ctx *Context) chan *StorageGroupResult {
 			     m3.provisioning.storage_groups 
 			OFFSET 
 				floor(random() * (SELECT COUNT(*) FROM m3.provisioning.storage_groups)) LIMIT 1;`
-
-		err := ctx.Tx.QueryRow(query).Scan(&id, &name, &num)
+		// non-transactional query as there cannot be a storage group insert along with a read
+		err := GetInstance().Db.QueryRow(query).Scan(&id, &name, &num)
 		if err != nil {
 			ch <- &StorageGroupResult{Error: err}
 			return
@@ -154,7 +154,13 @@ func GetListOfTenantsForStorageGroup(ctx *Context, sg *StorageGroup) chan []*Sto
 			LEFT JOIN m3.provisioning.tenants t2
 			ON t1.tenant_id = t2.id
 			WHERE storage_group_id=$1`
-		rows, err := ctx.Tx.Query(query, sg.ID)
+		// Create a transactional query as a list of tenants may be query as a new tenant is being inserted
+		tx, err := ctx.MainTx()
+		if err != nil {
+			return
+		}
+
+		rows, err := tx.Query(query, sg.ID)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -201,7 +207,12 @@ func GetAllTenantRoutes(ctx *Context) chan []*TenantRoute {
 			LEFT JOIN m3.provisioning.tenants t2
 			ON t1.tenant_id = t2.id
 		`
-		rows, err := ctx.Tx.Query(query)
+		// Transactional query tenants may be query as a new one is being inserted
+		tx, err := ctx.MainTx()
+		if err != nil {
+			return
+		}
+		rows, err := tx.Query(query)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -262,9 +273,14 @@ func createTenantInStorageGroup(ctx *Context, tenant *Tenant, sg *StorageGroup) 
 		     m3.provisioning.tenants_storage_groups
 		WHERE 
 		      storage_group_id=$1`
+
+		tx, err := ctx.MainTx()
+		if err != nil {
+			return
+		}
 		var totalTenantsCount int32
-		row := ctx.Tx.QueryRow(totalTenantsCountQuery, sg.ID)
-		err := row.Scan(&totalTenantsCount)
+		row := tx.QueryRow(totalTenantsCountQuery, sg.ID)
+		err = row.Scan(&totalTenantsCount)
 		if err != nil {
 			ch <- &StorageGroupTenantResult{
 				Error: err,
@@ -284,7 +300,7 @@ func createTenantInStorageGroup(ctx *Context, tenant *Tenant, sg *StorageGroup) 
 				                                          "service_name")
 			  VALUES
 				($1,$2,$3,$4)`
-		_, err = ctx.Tx.Exec(query, tenant.ID, sg.ID, port, serviceName)
+		_, err = tx.Exec(query, tenant.ID, sg.ID, port, serviceName)
 		if err != nil {
 			ch <- &StorageGroupTenantResult{
 				Error: err,
@@ -324,7 +340,7 @@ func GetTenantStorageGroupByShortName(ctx *Context, tenantShortName string) chan
 			LEFT JOIN m3.provisioning.storage_groups t3
 			ON t1.storage_group_id = t3.id
 			WHERE t2.short_name=$1 LIMIT 1`
-		rows, err := ctx.Tx.Query(query, tenantShortName)
+		rows, err := GetInstance().Db.Query(query, tenantShortName)
 		if err != nil {
 			ch <- &StorageGroupTenantResult{Error: err}
 			return

--- a/cluster/storage-cluster.go
+++ b/cluster/storage-cluster.go
@@ -250,6 +250,14 @@ func (sgt *StorageGroupTenant) Address() string {
 	return fmt.Sprintf("%s:%d", sgt.ServiceName, sgt.Port)
 }
 
+// Address returns the address where the tenant is located on the storage group with the http protocol in the url
+func (sgt *StorageGroupTenant) HTTPAddress(ssl bool) string {
+	if ssl {
+		return fmt.Sprintf("https://%s:%d", sgt.ServiceName, sgt.Port)
+	}
+	return fmt.Sprintf("http://%s:%d", sgt.ServiceName, sgt.Port)
+}
+
 type TenantRoute struct {
 	ShortName   string
 	Port        int32

--- a/cluster/storage-cluster.go
+++ b/cluster/storage-cluster.go
@@ -245,6 +245,11 @@ type StorageGroupTenant struct {
 	ServiceName string
 }
 
+// Address returns the address where the tenant is located on the storage group
+func (sgt *StorageGroupTenant) Address() string {
+	return fmt.Sprintf("%s:%d", sgt.ServiceName, sgt.Port)
+}
+
 type TenantRoute struct {
 	ShortName   string
 	Port        int32

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -1,0 +1,87 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+// AddUser adds a new user to the tenant's database
+func AddUser(tenantShortName string, userEmail string, userPassword string) error {
+	// validate userEmail
+	if userEmail != "" {
+		// TODO: improve regex
+		var re = regexp.MustCompile(`^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,4}$`)
+		if !re.MatchString(userEmail) {
+			return errors.New("a valid email is needed")
+		}
+	}
+	// validate userPassword
+	if userPassword != "" {
+		// TODO: improve regex or use Go validator
+		var re = regexp.MustCompile(`^[a-zA-Z0-9!@#\$%\^&\*]{8,16}$`)
+		if !re.MatchString(userPassword) {
+			return errors.New("a valid password is needed, minimum 8 characters")
+		}
+	}
+
+	bgCtx := context.Background()
+	db := GetInstance().GetTenantDB(tenantShortName)
+	tx, err := db.BeginTx(bgCtx, nil)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	ctx := NewContext(bgCtx, tx)
+	// Add parameters to query
+	userID := uuid.NewV4()
+	query := `INSERT INTO
+				users ("id","email","password")
+			  VALUES
+				($1,$2,$3)`
+	stmt, err := ctx.Tx.Prepare(query)
+	if err != nil {
+		tx.Rollback()
+		fmt.Println("here")
+		return err
+	}
+	defer stmt.Close()
+	// Execute query
+	_, err = ctx.Tx.Exec(query, userID, userEmail, userPassword)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	// Create this user's credentials so he can interact with it's own buckets/data
+	err = createUserCredentials(ctx, tenantShortName, userID)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	// if no error happened to this point commit transaction
+	err = tx.Commit()
+	if err != nil {
+		return nil
+	}
+	return nil
+}

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -96,24 +96,18 @@ func AddUser(tenantShortName string, userEmail string, userPassword string) erro
 	return nil
 }
 
-// GetUserWithPwd searches for the user in the defined tenant's database
+// GetUserByEmail searches for the user in the defined tenant's database
 // and returns the User if it was found
-func GetUserWithPwd(ctx *Context, tenant string, email string, password string) (user User, err error) {
-	// Hash the password
-	hashedPassword, err := HashPassword(password)
-	if err != nil {
-		return user, err
-	}
-
+func GetUserByEmail(ctx *Context, tenant string, email string) (user User, err error) {
 	// Get user from tenants database
 	queryUser := `
 		SELECT 
 				t1.id, t1.email, t1.password, t1.is_admin
 			FROM 
 				users t1
-			WHERE email=$1 AND password=$2`
+			WHERE email=$1 LIMIT 1`
 
-	row := ctx.TenantDB().QueryRow(queryUser, email, hashedPassword)
+	row := ctx.TenantDB().QueryRow(queryUser, email, password)
 
 	// Save the resulted query on the User struct
 	err = row.Scan(&user.UUID, &user.Email, &user.Password, &user.IsAdmin)

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -107,7 +107,7 @@ func GetUserByEmail(ctx *Context, tenant string, email string) (user User, err e
 				users t1
 			WHERE email=$1 LIMIT 1`
 
-	row := ctx.TenantDB().QueryRow(queryUser, email, password)
+	row := ctx.TenantDB().QueryRow(queryUser, email)
 
 	// Save the resulted query on the User struct
 	err = row.Scan(&user.UUID, &user.Email, &user.Password, &user.IsAdmin)

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -71,25 +71,25 @@ func AddUser(tenantShortName string, userEmail string, userPassword string) erro
 	}
 	stmt, err := tx.Prepare(query)
 	if err != nil {
-		tx.Rollback()
+		ctx.Rollback()
 		return err
 	}
 	defer stmt.Close()
 	// Execute query
 	_, err = tx.Exec(query, userID, userEmail, hashedPassword)
 	if err != nil {
-		tx.Rollback()
+		ctx.Rollback()
 		return err
 	}
 	// Create this user's credentials so he can interact with it's own buckets/data
 	err = createUserCredentials(ctx, tenantShortName, userID)
 	if err != nil {
-		tx.Rollback()
+		ctx.Rollback()
 		return err
 	}
 
 	// if no error happened to this point commit transaction
-	err = tx.Commit()
+	err = ctx.Commit()
 	if err != nil {
 		return nil
 	}

--- a/cluster/tenants.go
+++ b/cluster/tenants.go
@@ -302,10 +302,8 @@ func MakeBucket(tenantShortName string, bucketName string) error {
 		return err
 	}
 
-	// Build tenant address
-	tenantAddress := fmt.Sprintf("%s:%d", sgt.ServiceName, sgt.Port)
 	// Initialize minio client object.
-	minioClient, err := minio.New(tenantAddress,
+	minioClient, err := minio.New(sgt.Address(),
 		tenantConf.AccessKey,
 		tenantConf.SecretKey,
 		false)

--- a/cluster/utils.go
+++ b/cluster/utils.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"strings"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Do not use:
@@ -54,7 +54,7 @@ func RandomCharString(n int) string {
 	return s.String()
 }
 
-// GetOperatorCredentialsForTenant returns the access/secret keys for a given tenant
+// GetTenantConfig returns the access/secret keys for a given tenant
 func GetTenantConfig(shortName string) (*TenantConfiguration, error) {
 	clientset, err := k8sClient()
 	if err != nil {
@@ -62,7 +62,7 @@ func GetTenantConfig(shortName string) (*TenantConfiguration, error) {
 	}
 	// Get the tenant main secret
 	tenantSecretName := fmt.Sprintf("%s-env", shortName)
-	mainSecret, err := clientset.CoreV1().Secrets("default").Get(tenantSecretName, v1.GetOptions{})
+	mainSecret, err := clientset.CoreV1().Secrets("default").Get(tenantSecretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/utils.go
+++ b/cluster/utils.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"strings"
 
 	"github.com/minio/minio-go/v6"
@@ -117,4 +119,10 @@ func toLookupType(s string) minio.BucketLookupType {
 		return minio.BucketLookupPath
 	}
 	return minio.BucketLookupAuto
+}
+
+// HashPassword hashes the password one way
+func HashPassword(password string) (string, error) {
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 14)
+	return string(bytes), err
 }

--- a/cluster/utils.go
+++ b/cluster/utils.go
@@ -21,8 +21,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
+	"runtime"
+
 	"strings"
 
+	"github.com/minio/minio-go/v6"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -80,4 +84,37 @@ func GetTenantConfig(shortName string) (*TenantConfiguration, error) {
 	}
 	// Build configuration
 	return &conf, nil
+}
+
+// newS3Config simply creates a new Config struct using the passed
+// parameters.
+func newS3Config(appName, url string, hostCfg *hostConfigV9) *Config {
+	// We have a valid alias and hostConfig. We populate the
+	// credentials from the match found in the config file.
+	s3Config := new(Config)
+
+	s3Config.AppName = filepath.Base(appName)
+	s3Config.AppVersion = Version
+	s3Config.AppComments = []string{filepath.Base(appName), runtime.GOOS, runtime.GOARCH}
+
+	s3Config.HostURL = url
+	if hostCfg != nil {
+		s3Config.AccessKey = hostCfg.AccessKey
+		s3Config.SecretKey = hostCfg.SecretKey
+		s3Config.Signature = hostCfg.API
+	}
+	s3Config.Lookup = toLookupType(hostCfg.Lookup)
+	return s3Config
+}
+
+// getLookupType returns the minio.BucketLookupType for lookup
+// option entered on the command line
+func toLookupType(s string) minio.BucketLookupType {
+	switch strings.ToLower(s) {
+	case "dns":
+		return minio.BucketLookupDNS
+	case "path":
+		return minio.BucketLookupPath
+	}
+	return minio.BucketLookupAuto
 }

--- a/cmd/m3/tenant-user-add.go
+++ b/cmd/m3/tenant-user-add.go
@@ -30,7 +30,7 @@ var (
 
 // Adds a user to the tenant's database
 var tenantAddUserCmd = cli.Command{
-	Name:   "add-user",
+	Name:   "add",
 	Usage:  "Adds a user to the defined tenant",
 	Action: tenantAddUser,
 	Flags: []cli.Flag{

--- a/cmd/m3/tenant-user.go
+++ b/cmd/m3/tenant-user.go
@@ -22,7 +22,7 @@ import "github.com/minio/cli"
 var tenantUserCmd = cli.Command{
 	Name:   "user",
 	Usage:  "user subcommands",
-	Action: showClusterHelp,
+	Action: showTenantUserHelp,
 	Subcommands: []cli.Command{
 		tenantAddUserCmd,
 	},

--- a/cmd/m3/tenant-user.go
+++ b/cmd/m3/tenant-user.go
@@ -16,22 +16,18 @@
 
 package main
 
-import (
-	"github.com/minio/cli"
-)
+import "github.com/minio/cli"
 
 // list files and folders.
-var tenantCmd = cli.Command{
-	Name:   "tenant",
-	Usage:  "tenant commands",
-	Action: tenantDefCmd,
+var tenantUserCmd = cli.Command{
+	Name:   "user",
+	Usage:  "user subcommands",
+	Action: showClusterHelp,
 	Subcommands: []cli.Command{
-		addTenantCmd,
-		tenantMbCmd,
-		tenantUserCmd,
+		tenantAddUserCmd,
 	},
 }
 
-func tenantDefCmd(ctx *cli.Context) error {
+func showTenantUserHelp(ctx *cli.Context) error {
 	return cli.ShowAppHelp(ctx)
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/minio/minio v0.0.0-20190920231956-112729386357
 	github.com/minio/minio-go/v6 v6.0.35
 	github.com/satori/go.uuid v1.2.0
+	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/tools v0.0.0-20191015150414-f936694f27bf // indirect
 	google.golang.org/grpc v1.20.1
 	k8s.io/api v0.0.0-20190313115550-3c12c96769cc

--- a/portal/api-authentication-grpc.go
+++ b/portal/api-authentication-grpc.go
@@ -55,7 +55,6 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (res *pb.LoginR
 	}
 
 	// Add the session within a transaction in case anything goes wrong during the adding process
-
 	defer func() {
 		if err != nil {
 			res = &pb.LoginResponse{

--- a/portal/api-authentication-grpc.go
+++ b/portal/api-authentication-grpc.go
@@ -32,7 +32,6 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (res *pb.LoginR
 	// TODO: validate credentials: username->email, tenant->shortname?
 	tenantName := in.GetCompany()
 	email := in.GetEmail()
-	pwd := in.GetPassword()
 
 	// Search for the tenant on the database
 	tenant, err := cluster.GetTenant(tenantName)

--- a/portal/api-authentication-grpc.go
+++ b/portal/api-authentication-grpc.go
@@ -18,26 +18,10 @@ package portal
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha256"
-	"fmt"
-	"io"
-	"time"
 
-	"encoding/base64"
-
-	pq "github.com/lib/pq"
 	cluster "github.com/minio/m3/cluster"
 	pb "github.com/minio/m3/portal/stubs"
 )
-
-type User struct {
-	Tenant   string
-	Email    string
-	IsAdmin  bool
-	Password string
-	UUID     string
-}
 
 // Login handles the Login request by receiving the user credentials
 // and returning a hashed token.
@@ -49,19 +33,21 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (res *pb.LoginR
 	pwd := in.GetPassword()
 
 	// Search for the tenant on the database
-	tenant, err := getTenant(tenantName)
+	tenant, err := cluster.GetTenant(tenantName)
 	if err != nil {
 		res = &pb.LoginResponse{
 			Error: "Tenant not valid",
 		}
 		return res, nil
 	}
+	// start app context
+	appCtx, err := cluster.NewContext(tenantName)
 
 	// Password validation
 	// Look for the user on the database by email AND pwd,
 	// if it doesn't exist it means that the email AND password don't match, therefore wrong credentials.
 	// TODO: hash password and pass it to the getUser assuming db has hashed password also.
-	user, err := getUser(tenant.Name, email, pwd)
+	user, err := cluster.GetUser(appCtx, tenant.Name, email, pwd)
 	if err != nil {
 		res = &pb.LoginResponse{
 			Error: "Wrong tenant, email and/or password",
@@ -70,145 +56,27 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (res *pb.LoginR
 	}
 
 	// Add the session within a transaction in case anything goes wrong during the adding process
-	db := cluster.GetInstance().Db
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		res = &pb.LoginResponse{
-			Error: err.Error(),
-		}
-		return res, nil
-	}
 
 	defer func() {
 		if err != nil {
 			res = &pb.LoginResponse{
 				Error: err.Error(),
 			}
-			tx.Rollback()
+			appCtx.Rollback()
 			return
 		}
 		// if no error happened to this point commit transaction
-		err = tx.Commit()
+		err = appCtx.Commit()
 	}()
-
-	// Set query parameters
-	// Insert a new session with random string as id
-	sessionID, err := GetRandString(32, "sha256")
-	if err != nil {
-		return res, err
-	}
-
-	query :=
-		`INSERT INTO
-				m3.provisioning.sessions ("id","user_id", "tenant_id", "occurred_at")
-			  VALUES
-				($1,$2,$3,$4)`
-
-	// Execute Query
-	_, err = tx.Exec(query, sessionID, user.UUID, tenant.ID, time.Now())
+	// Everything looks good, create session
+	sessionID, err := cluster.CreateSession(appCtx, user.UUID, tenant.ID)
 	if err != nil {
 		return res, err
 	}
 
 	// Return session in Token Response
 	res = &pb.LoginResponse{
-		JwtToken: sessionID,
+		JwtToken: *sessionID,
 	}
 	return res, nil
-}
-
-// getUser searches for the user in the defined tenant's database
-// and returns the User if it was found
-func getUser(tenant string, email string, password string) (user User, err error) {
-	bgCtx := context.Background()
-	db := cluster.GetInstance().GetTenantDB(tenant)
-
-	tx, err := db.BeginTx(bgCtx, nil)
-	if err != nil {
-		return user, err
-	}
-
-	// rollback transaction if any error occurs when getUser returns
-	// else, commit transaction
-	defer func() {
-		if err != nil {
-			tx.Rollback()
-			return
-		}
-		// if no error happened to this point commit transaction
-		err = tx.Commit()
-	}()
-
-	// Get user from tenants database
-	quoted := pq.QuoteIdentifier(tenant)
-	queryUser := fmt.Sprintf(`
-		SELECT 
-				t1.id, t1.email, t1.password, t1.is_admin
-			FROM 
-				tenants.%s.users t1
-			WHERE email=$1 AND password=$2`, quoted)
-	row := tx.QueryRow(queryUser, email, password)
-
-	// Save the resulted query on the User struct
-	err = row.Scan(&user.UUID, &user.Email, &user.Password, &user.IsAdmin)
-	if err != nil {
-		return user, err
-	}
-
-	// add tenant shortname to the User
-	user.Tenant = tenant
-	return user, nil
-}
-
-// getTenant gets the Tenant if it exists on the m3.provisining.tenants table
-// search is done by tenant name
-func getTenant(tenantName string) (tenant cluster.Tenant, err error) {
-	bgCtx := context.Background()
-	db := cluster.GetInstance().Db
-
-	tx, err := db.BeginTx(bgCtx, nil)
-	if err != nil {
-		return tenant, err
-	}
-
-	// rollback transaction if any error occurs when getTenant returns
-	// else, commit transaction
-	defer func() {
-		if err != nil {
-			tx.Rollback()
-			return
-		}
-		err = tx.Commit()
-	}()
-
-	query :=
-		`SELECT 
-				t1.id, t1.name, t1.short_name
-			FROM 
-				m3.provisioning.tenants t1
-			WHERE name=$1`
-	row := tx.QueryRow(query, tenantName)
-
-	// Save the resulted query on the User struct
-	err = row.Scan(&tenant.ID, &tenant.Name, &tenant.ShortName)
-	if err != nil {
-		return tenant, err
-	}
-	return tenant, nil
-}
-
-// GetRandString generates a random string with the defined size length
-func GetRandString(size int, method string) (string, error) {
-	rb := make([]byte, size)
-	if _, err := io.ReadFull(rand.Reader, rb); err != nil {
-		return "", err
-	}
-
-	randStr := base64.URLEncoding.EncodeToString(rb)
-	if method == "sha256" {
-		h := sha256.New()
-		h.Write([]byte(randStr))
-		randStr = fmt.Sprintf("%x", h.Sum(nil))
-	}
-	return randStr, nil
 }

--- a/portal/api-authentication-grpc.go
+++ b/portal/api-authentication-grpc.go
@@ -46,8 +46,7 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (res *pb.LoginR
 	// Password validation
 	// Look for the user on the database by email AND pwd,
 	// if it doesn't exist it means that the email AND password don't match, therefore wrong credentials.
-	// TODO: hash password and pass it to the getUser assuming db has hashed password also.
-	user, err := cluster.GetUser(appCtx, tenant.Name, email, pwd)
+	user, err := cluster.GetUserWithPwd(appCtx, tenant.Name, email, pwd)
 	if err != nil {
 		res = &pb.LoginResponse{
 			Error: "Wrong tenant, email and/or password",

--- a/portal/utils.go
+++ b/portal/utils.go
@@ -17,46 +17,8 @@
 package portal
 
 import (
-	"path/filepath"
-	"runtime"
-	"strings"
 	"time"
-
-	"github.com/minio/minio-go/v6"
 )
-
-// newS3Config simply creates a new Config struct using the passed
-// parameters.
-func newS3Config(appName, url string, hostCfg *hostConfigV9) *Config {
-	// We have a valid alias and hostConfig. We populate the
-	// credentials from the match found in the config file.
-	s3Config := new(Config)
-
-	s3Config.AppName = filepath.Base(appName)
-	s3Config.AppVersion = Version
-	s3Config.AppComments = []string{filepath.Base(appName), runtime.GOOS, runtime.GOARCH}
-
-	s3Config.HostURL = url
-	if hostCfg != nil {
-		s3Config.AccessKey = hostCfg.AccessKey
-		s3Config.SecretKey = hostCfg.SecretKey
-		s3Config.Signature = hostCfg.API
-	}
-	s3Config.Lookup = toLookupType(hostCfg.Lookup)
-	return s3Config
-}
-
-// getLookupType returns the minio.BucketLookupType for lookup
-// option entered on the command line
-func toLookupType(s string) minio.BucketLookupType {
-	switch strings.ToLower(s) {
-	case "dns":
-		return minio.BucketLookupDNS
-	case "path":
-		return minio.BucketLookupPath
-	}
-	return minio.BucketLookupAuto
-}
 
 // UTCNow - returns current UTC time.
 func UTCNow() time.Time {


### PR DESCRIPTION
What's going on on this PR?

- The functionality to create the UI Credentials on `add user` was implemented.
  - When the UI Credential is generated it is committed to the Tenant's MinIO
  - The new `MinIO User` or access key, is granted `readwrite` policy
  - The secret key is stored on k8s
- Command `./m3 tenant add-user` was renamed to `./m3 tenant user add` 

To achieve these simple things one thing had to be fixed, we have a main schema (m3.provisioning) and each tenant has it's own schema, we were opening a `cluster.Context` based on what we planned to query/insert, however adding a credential represents the first mix of the two, therefore I made it so Context houses both Tenant DB Transactions and Main DB Transactions, moreover this transactions are not started until they are requested via `ctx.TenantTx()` or `ctx.MainTx()`, additionally, for scenarios where we only need to read from either DB and not insert, we don't need to open a transaction for the database, here the tenant DB can be reached using `ctx.TenantDB()` and the main db can be acccessed via `cluster.GetInstance().Db`

I had to adjust all the code that relies on `cluster.Context` and align it with the new db paradigm.

It's important to note that the `ctx.TenantDB()` and `ctx.TenantTx()` objects are already configured to use the proper database and schema, so it's not needed to include that in the query, it was error prone to have to put it in on every query/function. On subsequent transactions `m3.provisioning` will be removed from Main DB queries.

Also we need to honor the `ctx.WhoAmI` and always insert it to the `created_by` field on all the tenant tables.
