### PR TITLE
Delete tenant command

### DIFF
--- a/cluster/connections.go
+++ b/cluster/connections.go
@@ -176,3 +176,8 @@ func GetTenantDBConfig(tenantName string) *DbConfig {
 	config.SchemaName = tenantName
 	return config
 }
+
+// RemoveCnx removes a tenant DB connection from the cache
+func (s *Singleton) RemoveCnx(tenantName string) {
+	delete(s.tenantsCnx, tenantName)
+}

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -59,7 +59,7 @@ func (c *Context) TenantDB() *sql.DB {
 
 // TenantTx returns a transaction against the Tenant DB, if none has been started, it starts one
 func (c *Context) TenantTx() (*sql.Tx, error) {
-	if c.mainTx == nil {
+	if c.tenantTx == nil {
 		db := c.TenantDB()
 		tx, err := db.BeginTx(c.ControlCtx, nil)
 		if err != nil {

--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -19,7 +19,6 @@ package cluster
 import (
 	"errors"
 	"fmt"
-	"log"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,7 +84,6 @@ func createUserCredentials(ctx *Context, tenantShortName string, userdID uuid.UU
 	stmt, err := tx.Prepare(query)
 	if err != nil {
 		ctx.Rollback()
-		log.Fatal(err)
 		return err
 	}
 	defer stmt.Close()

--- a/cluster/minio-tenant.go
+++ b/cluster/minio-tenant.go
@@ -29,8 +29,9 @@ func mkTenantMinioContainer(sgTenant *StorageGroupTenant, hostNum string) (v1.Co
 	envName := fmt.Sprintf("%s-env", sgTenant.ShortName)
 	volumeMounts := []v1.VolumeMount{}
 	tenantContainer := v1.Container{
-		Name:            fmt.Sprintf("%s-minio-%s", sgTenant.Tenant.ShortName, hostNum),
-		Image:           "minio/minio:latest",
+		Name:  fmt.Sprintf("%s-minio-%s", sgTenant.Tenant.ShortName, hostNum),
+		Image: "minio/minio:RELEASE.2019-10-12T01-39-57Z",
+		//Image:           "minio/minio:latest",
 		ImagePullPolicy: "IfNotPresent",
 		Args: []string{
 			"server",

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -37,7 +37,7 @@ func addMinioCannedPolicyToUser(sgt *StorageGroupTenant, tenantConf *TenantConfi
 		return pErr.Cause
 	}
 	// Add the canned policy
-	err := adminClient.AddCannedPolicy(accessKey, policy)
+	err := adminClient.SetPolicy(policy, accessKey, false)
 	if err != nil {
 		return err
 	}

--- a/cluster/nginx.go
+++ b/cluster/nginx.go
@@ -162,9 +162,12 @@ func DeleteNginxLBDeployment(clientset *kubernetes.Clientset, deploymentName, ap
 //
 // N B If an nginx-resolver is already running we delete the deployment and create a
 // new one that reads the updated rules.
-func DeployNginxResolver(shouldUpdate bool) {
+func DeployNginxResolver(shouldUpdate bool) error {
 	// creates the clientset
 	clientset, err := k8sClient()
+	if err != nil {
+		return err
+	}
 	if shouldUpdate {
 		// Delete nginx-resolver deployment and wait until all its pods
 		// are deleted too. This is to ensure that the creation of the
@@ -176,14 +179,15 @@ func DeployNginxResolver(shouldUpdate bool) {
 
 		fmt.Println("creating nginx-resolver deployment with updated rules")
 		if _, err = extV1beta1API(clientset).Deployments("default").Create(&nginxLBDeployment); err != nil {
-			panic(err.Error())
+			return err
 		}
 	} else {
 		if _, err = extV1beta1API(clientset).Deployments("default").Create(&nginxLBDeployment); err != nil {
-			panic(err.Error())
+			return err
 		}
 	}
 	fmt.Println("done creating nginx-resolver deployment ")
+	return nil
 }
 
 // UpdateNginxConfiguration Update the nginx.conf ConfigMap used by the nginx-resolver service

--- a/cluster/setup.go
+++ b/cluster/setup.go
@@ -232,8 +232,7 @@ events {
 	}
 	fmt.Println("done with nginx-resolver configMaps")
 	fmt.Println(resConfigMap.String())
-	shouldUpdate := false
-	DeployNginxResolver(shouldUpdate)
+	DeployNginxResolver(false)
 }
 
 // This runs all the migrations on the cluster/migrations folder, if some migrations were already applied it then will

--- a/cmd/m3/tenant-delete.go
+++ b/cmd/m3/tenant-delete.go
@@ -1,0 +1,73 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/minio/cli"
+	"github.com/minio/m3/cluster"
+)
+
+// list files and folders.
+var tenantDeleteCmd = cli.Command{
+	Name:   "delete",
+	Usage:  "delete a tenant",
+	Action: tenantDelete,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "name",
+			Value: "",
+			Usage: "Name of the tenant",
+		},
+		cli.BoolFlag{
+			Name:  "confirm",
+			Usage: "Confirm you want to delete the tenant",
+		},
+	},
+}
+
+// Command to add a new tenant, it has a mandatory parameter for the tenant name and an optional parameter for
+// the short name, if the short name cannot be inferred from the name (in case of unicode) the command will fail.
+// sample usage:
+//     m3 tenant add tenant-1
+//     m3 tenant add --name tenant-1
+//     m3 tenant add tenant-1 --short_name tenant1
+//     m3 tenant add --name tenant-1 --short_name tenant1
+func tenantDelete(ctx *cli.Context) error {
+	name := ctx.String("name")
+	confirm := ctx.Bool("confirm")
+	if name == "" && ctx.Args().Get(0) != "" {
+		name = ctx.Args().Get(0)
+	}
+	if name == "" {
+		fmt.Println("You must provide tenant name")
+		return nil
+	}
+	if !confirm {
+		fmt.Println("You must pass the confirm flag")
+		return nil
+	}
+	fmt.Println("Deleting tenant:", name)
+	err := cluster.DeleteTenant(name)
+	if err != nil {
+		fmt.Println(err.Error())
+		return nil
+	}
+	fmt.Println("Done deleting tenant!")
+	return nil
+}

--- a/cmd/m3/tenant.go
+++ b/cmd/m3/tenant.go
@@ -29,6 +29,7 @@ var tenantCmd = cli.Command{
 		addTenantCmd,
 		tenantMbCmd,
 		tenantUserCmd,
+		tenantDeleteCmd,
 	},
 }
 


### PR DESCRIPTION
Introduces `./m3 tenant delete TENANNAME --confirm` command to remove a tenant from the m3 cluster.

The command starts by removing the tenant from the tenant table and the starts removing all the tenant configurations (secrets, services), removes the tenant from the router and finally redeploys the storage group it resides on. 

`ReDeployStorageGroup` had to be updated as removing tenants and adding new ones was causing a problem where duplicate or ghost volumes were being kept