### PR TITLE
Router Refresh command and Fixes

### DIFF
--- a/cmd/m3/cluster-router-refresh.go
+++ b/cmd/m3/cluster-router-refresh.go
@@ -17,22 +17,32 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/minio/cli"
 	"github.com/minio/m3/cluster"
 )
 
 // list files and folders.
-var clusterCmd = cli.Command{
-	Name:   "cluster",
-	Usage:  "runs cluster commands",
-	Action: listPodsCmd,
-	Subcommands: []cli.Command{
-		storageClusterCmd,
-		clusterRouterCmd,
-	},
+var routerRefreshCmd = cli.Command{
+	Name:   "refresh",
+	Usage:  "redeploys the cluster router",
+	Action: routerRefresh,
 }
 
-func listPodsCmd(ctx *cli.Context) error {
-	cluster.ListPods()
+// Adds a Storage Group to house multiple tenants
+func routerRefresh(ctx *cli.Context) error {
+	fmt.Println("Refreshing Router")
+	appCtx, err := cluster.NewContext("none")
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+	err = <-cluster.UpdateNginxConfiguration(appCtx)
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
 	return nil
 }

--- a/cmd/m3/cluster-router.go
+++ b/cmd/m3/cluster-router.go
@@ -18,21 +18,18 @@ package main
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/m3/cluster"
 )
 
 // list files and folders.
-var clusterCmd = cli.Command{
-	Name:   "cluster",
-	Usage:  "runs cluster commands",
-	Action: listPodsCmd,
+var clusterRouterCmd = cli.Command{
+	Name:   "router",
+	Usage:  "Router sub commands",
+	Action: showRouterHelp,
 	Subcommands: []cli.Command{
-		storageClusterCmd,
-		clusterRouterCmd,
+		routerRefreshCmd,
 	},
 }
 
-func listPodsCmd(ctx *cli.Context) error {
-	cluster.ListPods()
-	return nil
+func showRouterHelp(ctx *cli.Context) error {
+	return cli.ShowAppHelp(ctx)
 }


### PR DESCRIPTION
Introduces command to refresh the cluster router, this is useful when the cluster is in a bad state and you want to force an nginx configuration refresh.

This also introduces a default server on the nginx config so we return 404 if a bad address is accessed.