### PR TITLE
mkube admins to control access to the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ For development we need to port-forward the kubernetes pods after we add a new t
   sudo -E kubefwd svc -n default
 ```
 ---
+
+## Adding an Admin User
+```shell
+  ./m3 admin add "Admin Name" admin@email.com 
+```
 ## Making a bucket on a tenant
 ```shell
   ./m3 tenant bucket add tenant-short-name bucket-name

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ $ kubectl get secret $(kubectl get serviceaccount dashboard -o jsonpath="{.secre
 
 2. Run `m3 setup` on the local kubernetes
 ```shell
-   ./m3 setup
+   ./m3 setup "Admin Name" admin@email.com
 ```
+This will setup `mkube` and create the first admin account **Write down the admin access/secret key**
+
 At the moment, you would see the following error message,
 ```
 Running Migrations

--- a/cluster/admins.go
+++ b/cluster/admins.go
@@ -1,0 +1,151 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+type Admin struct {
+	ID        uuid.UUID
+	Name      string
+	Email     string
+	AccessKey string
+	SecretKey string
+}
+
+// AddAdmin adds a new admin to the cluster database and creates a key pair for it.
+func AddAdmin(name string, adminEmail string) (*Admin, error) {
+	// validate adminEmail
+	if adminEmail != "" {
+		// TODO: improve regex
+		var re = regexp.MustCompile(`^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,4}$`)
+		if !re.MatchString(adminEmail) {
+			return nil, errors.New("a valid email is needed")
+		}
+	}
+
+	ctx, err := NewContext("")
+	if err != nil {
+		return nil, err
+	}
+
+	admin := Admin{
+		ID:        uuid.NewV4(),
+		Name:      name,
+		Email:     adminEmail,
+		AccessKey: RandomCharString(16),
+		SecretKey: RandomCharString(32),
+	}
+
+	query := `INSERT INTO
+				provisioning.admins ("id", "name", "email", "access_key","sys_created_by")
+			  VALUES
+				($1, $2, $3, $4, $5)`
+	tx, err := ctx.MainTx()
+	if err != nil {
+		return nil, err
+	}
+	stmt, err := tx.Prepare(query)
+	if err != nil {
+		ctx.Rollback()
+		return nil, err
+	}
+	defer stmt.Close()
+	// Execute query
+	_, err = tx.Exec(query, admin.ID, admin.Name, admin.Email, admin.AccessKey, ctx.WhoAmI)
+	if err != nil {
+		ctx.Rollback()
+		return nil, err
+	}
+	// Create this user's credentials so he can interact with it's own buckets/data
+	err = storeAdminCredentials(&admin)
+	if err != nil {
+		ctx.Rollback()
+		return nil, err
+	}
+
+	// if no error happened to this point commit transaction
+	err = ctx.Commit()
+	if err != nil {
+		return nil, err
+	}
+	return &admin, nil
+}
+
+// storeAdminCredentials saves the credentials for an Admin to a k8s secret on the m3 namespace
+func storeAdminCredentials(admin *Admin) error {
+	// creates the clientset
+	clientset, err := k8sClient()
+
+	if err != nil {
+		return err
+	}
+
+	// store the crendential exclusively for this user, this way there can only be 1 credentials per use
+	secretsName := fmt.Sprintf("admin-%s", admin.ID.String())
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretsName,
+			Labels: map[string]string{
+				"app": admin.ID.String(),
+			},
+		},
+		Data: map[string][]byte{
+			accessKey: []byte(admin.AccessKey),
+			secretKey: []byte(admin.SecretKey),
+		},
+	}
+	_, err = clientset.CoreV1().Secrets(m3Namespace).Create(&secret)
+	return err
+}
+
+// GetAdminCredentials returns the access/secret key pair for a given admin
+func GetAdminCredentials(admin *Admin) error {
+	clientset, err := k8sClient()
+	if err != nil {
+		return err
+	}
+	// the admin secret is behind it's identifier
+	secretsName := fmt.Sprintf("admin-%s", admin.ID.String())
+	mainSecret, err := clientset.CoreV1().Secrets(m3Namespace).Get(secretsName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Validate access key
+	if val, ok := mainSecret.Data[accessKey]; ok {
+		if string(val) != admin.AccessKey {
+			return errors.New("access key does not match")
+		}
+	} else {
+		return errors.New("secret has no access key")
+	}
+	if val, ok := mainSecret.Data[accessKey]; ok {
+		admin.SecretKey = string(val)
+	} else {
+		return errors.New("secret has no secret key")
+	}
+	return nil
+}

--- a/cluster/migrations/000001_m3-initial.up.sql
+++ b/cluster/migrations/000001_m3-initial.up.sql
@@ -9,7 +9,7 @@ create table provisioning.admins
     email varchar(256) not null,
     access_key         varchar(256)                           not null,
     sys_created_by varchar(256) not null,
-    sys_date_created timestamptz default now() not null
+    sys_created_date timestamptz default now() not null
 );
 
 create unique index admins_email_uindex

--- a/cluster/migrations/000001_m3-initial.up.sql
+++ b/cluster/migrations/000001_m3-initial.up.sql
@@ -1,5 +1,23 @@
 create schema provisioning;
 
+create table provisioning.admins
+(
+    id uuid
+        constraint admins_pk
+            primary key,
+    name varchar(256),
+    email varchar(256) not null,
+    access_key         varchar(256)                           not null,
+    sys_created_by varchar(256) not null,
+    sys_date_created timestamptz default now() not null
+);
+
+create unique index admins_email_uindex
+    on provisioning.admins (email);
+
+create index admins_access_key_uindex
+    on provisioning.admins (access_key);
+
 create table provisioning.tenants
 (
     id         uuid         not null

--- a/cluster/setup.go
+++ b/cluster/setup.go
@@ -36,15 +36,30 @@ const (
 )
 
 // Setups m3 on the kubernetes deployment that we are installed to
-func SetupM3() {
+func SetupM3(name, email string) error {
+	// setup m3 namespace on k8s
 	fmt.Println("Setting up m3 namespace")
 	setupM3Namespace()
+	// setup nginx router
 	fmt.Println("setting up nginx")
 	SetupNginxLoadBalancer()
+	// setup database
 	fmt.Println("Setting up postgres")
 	setupPostgres()
+	// Add the first cluster admin
+	fmt.Println("Adding the first admin")
+	admin, err := AddAdmin(name, email)
+	if err != nil {
+		fmt.Println("Error adding user:", err.Error())
+		return err
+	}
+	fmt.Printf("Access Key: %s\n", admin.AccessKey)
+	fmt.Printf("Secret Key: %s\n", admin.SecretKey)
+	fmt.Println("Write these credentials down as this is the only time the secret will be shown.")
+	// run migrations
 	fmt.Println("Running Migrations")
 	RunMigrations()
+	return nil
 }
 
 // setupM3Namespace Setups the namespace used by the provisioning service

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -68,7 +68,7 @@ func AddUser(tenantShortName string, newUser *User) error {
 		return err
 	}
 	// Add parameters to query
-	newUser.UUID = uuid.NewV4()
+	newUser.ID = uuid.NewV4()
 	query := `INSERT INTO
 				users ("id","full_name","email","password")
 			  VALUES
@@ -84,13 +84,13 @@ func AddUser(tenantShortName string, newUser *User) error {
 	}
 	defer stmt.Close()
 	// Execute query
-	_, err = tx.Exec(query, newUser.UUID, newUser.Name, newUser.Email, hashedPassword)
+	_, err = tx.Exec(query, newUser.ID, newUser.Name, newUser.Email, hashedPassword)
 	if err != nil {
 		ctx.Rollback()
 		return err
 	}
 	// Create this user's credentials so he can interact with it's own buckets/data
-	err = createUserCredentials(ctx, tenantShortName, newUser.UUID)
+	err = createUserCredentials(ctx, tenantShortName, newUser.ID)
 	if err != nil {
 		ctx.Rollback()
 		return err

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -27,7 +27,7 @@ type User struct {
 	Email    string
 	IsAdmin  bool
 	Password string
-	UUID     uuid.UUID
+	ID       uuid.UUID
 }
 
 // AddUser adds a new user to the tenant's database
@@ -56,7 +56,7 @@ func AddUser(tenantShortName string, userEmail string, userPassword string) erro
 
 	ctx, err := NewContext(tenantShortName)
 	if err != nil {
-		return nil
+		return err
 	}
 	// Add parameters to query
 	userID := uuid.NewV4()
@@ -90,7 +90,7 @@ func AddUser(tenantShortName string, userEmail string, userPassword string) erro
 	// if no error happened to this point commit transaction
 	err = ctx.Commit()
 	if err != nil {
-		return nil
+		return err
 	}
 	return nil
 }
@@ -109,7 +109,7 @@ func GetUserByEmail(ctx *Context, tenant string, email string) (user User, err e
 	row := ctx.TenantDB().QueryRow(queryUser, email)
 
 	// Save the resulted query on the User struct
-	err = row.Scan(&user.UUID, &user.Email, &user.Password, &user.IsAdmin)
+	err = row.Scan(&user.ID, &user.Email, &user.Password, &user.IsAdmin)
 	if err != nil {
 		return user, err
 	}
@@ -138,7 +138,7 @@ func GetUsersForTenant(ctx *Context, offset int, limit int) ([]*User, error) {
 	var users []*User
 	for rows.Next() {
 		usr := User{}
-		err := rows.Scan(&usr.UUID, &usr.Email, &usr.IsAdmin)
+		err := rows.Scan(&usr.ID, &usr.Email, &usr.IsAdmin)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/m3/admin-add.go
+++ b/cmd/m3/admin-add.go
@@ -23,17 +23,30 @@ import (
 	"github.com/minio/m3/cluster"
 )
 
-// list files and folders.
-var setupCmd = cli.Command{
-	Name:   "setup",
-	Usage:  "Setups the m3 cluster",
-	Action: setupDefCmd,
-	Subcommands: []cli.Command{
-		setupDbCmd,
+// Adds a user to the tenant's database
+var adminAddCmd = cli.Command{
+	Name:   "add",
+	Usage:  "Adds an admin to the defined tenant",
+	Action: adminAdd,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "name",
+			Value: "",
+			Usage: "admin name",
+		},
+		cli.StringFlag{
+			Name:  "email",
+			Value: "",
+			Usage: "user email",
+		},
 	},
 }
 
-func setupDefCmd(ctx *cli.Context) error {
+// adminAdd is a command to add a cluster admin.
+// sample usage:
+//     m3 admin add "User Name" user@acme.com
+//     m3 admin add --name "User Name" --email user@acme.com
+func adminAdd(ctx *cli.Context) error {
 	name := ctx.String("name")
 	email := ctx.String("email")
 	if name == "" && ctx.Args().Get(0) != "" {
@@ -44,14 +57,26 @@ func setupDefCmd(ctx *cli.Context) error {
 	}
 
 	if name == "" {
-		fmt.Println("An admin name is needed")
+		fmt.Println("Admin name is needed")
 		return errMissingArguments
 	}
 
 	if email == "" {
-		fmt.Println("An admin email is needed")
+		fmt.Println("Admin email is needed")
 		return errMissingArguments
 	}
-	cluster.SetupM3(name, email)
+
+	// perform the action
+	admin, err := cluster.AddAdmin(name, email)
+	if err != nil {
+		fmt.Println("Error adding user:", err.Error())
+		return err
+	}
+
+	fmt.Printf("Done adding admin `%s <%s>`\n", admin.Name, admin.Email)
+	fmt.Printf("Access Key: %s\n", admin.AccessKey)
+	fmt.Printf("Secret Key: %s\n", admin.SecretKey)
+	fmt.Println("Write these credentials down as this is the only time the secret will be shown.")
+
 	return nil
 }

--- a/cmd/m3/admin.go
+++ b/cmd/m3/admin.go
@@ -14,13 +14,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package cluster
+package main
 
-const (
-	Version        = `0.1.0`
-	minioAccessKey = "MINIO_ACCESS_KEY"
-	minioSecretKey = "MINIO_SECRET_KEY"
-	accessKey      = "ACCESS_KEY"
-	secretKey      = "SECRET_KEY"
-	m3Namespace    = "default"
+import (
+	"github.com/minio/cli"
 )
+
+// commands to interact with cluster admins
+var adminCmd = cli.Command{
+	Name:   "admin",
+	Usage:  "admin commands",
+	Action: adminHelp,
+	Subcommands: []cli.Command{
+		adminAddCmd,
+	},
+}
+
+func adminHelp(ctx *cli.Context) error {
+	return cli.ShowAppHelp(ctx)
+}

--- a/cmd/m3/main.go
+++ b/cmd/m3/main.go
@@ -28,6 +28,7 @@ var appCmds = []cli.Command{
 	clusterCmd,
 	tenantCmd,
 	setupCmd,
+	adminCmd,
 }
 
 func main() {

--- a/cmd/m3/setup.go
+++ b/cmd/m3/setup.go
@@ -53,5 +53,5 @@ func setupDefCmd(ctx *cli.Context) error {
 		return errMissingArguments
 	}
 	cluster.SetupM3(name, email)
-	return nil
+	return cluster.SetupM3(name, email)
 }

--- a/cmd/m3/setup.go
+++ b/cmd/m3/setup.go
@@ -52,6 +52,5 @@ func setupDefCmd(ctx *cli.Context) error {
 		fmt.Println("An admin email is needed")
 		return errMissingArguments
 	}
-	cluster.SetupM3(name, email)
 	return cluster.SetupM3(name, email)
 }

--- a/cmd/m3/tenant-user-list.go
+++ b/cmd/m3/tenant-user-list.go
@@ -100,7 +100,7 @@ func tenantUserList(ctx *cli.Context) error {
 	fmt.Println("ID\tEmail\tIs Admin")
 	// Translate the users to friendly format
 	for _, user := range users {
-		fmt.Println(fmt.Sprintf("%s\t%s\t%t", user.UUID.String(), user.Email, user.IsAdmin))
+		fmt.Println(fmt.Sprintf("%s\t%s\t%t", user.ID.String(), user.Email, user.IsAdmin))
 	}
 	fmt.Println(fmt.Sprintf("A total of %d users", total))
 

--- a/portal/api-authentication-grpc.go
+++ b/portal/api-authentication-grpc.go
@@ -66,7 +66,7 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (res *pb.LoginR
 		err = appCtx.Commit()
 	}()
 	// Everything looks good, create session
-	session, err := cluster.CreateSession(appCtx, user.UUID, tenant.ID)
+	session, err := cluster.CreateSession(appCtx, user.ID, tenant.ID)
 	if err != nil {
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}


### PR DESCRIPTION
This resource will be the base to control access to the mkube backend.

An `admin` will be the one that can issue `./m3` commands, he will need to authenticate himself signing his commands with his secret, initially we can use HMAC for that, and later on move to issue certificates or something stronger.

Upon setup of `mkube` an access/secret key is generated (these keys have nothing to do with MinIO access/secret keys) and stored on kubernetes.

This PR contains the table, and the command to add a new admin.

Subsequent PRs will introduce the authentication mechanism, where for an `m3` command to run, the provided credentials must be present either as an environment variable or in a file.