### PR TITLE
Move setup of db and creation of admin to m3-setup-db

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,26 +83,34 @@ make m3
 - Run `m3 setup` on the local kubernetes
 
 ```
-./m3 setup "Admin Name" admin@email.com
+./m3 setup
 ```
 
-This will setup `m3` and create the first admin account **Note down the admin access/secret key**
+- Make postgres reachable from host OS
 
-You may see the following error message
+```
+kubectl port-forward -n m3 svc/postgres 5432
+```
+
+- To setup db
+
+```
+./m3 setup db
+```
+
+You may see the following error message since at times the postgres container is not running yet.
 ```
 Running Migrations
 2019/10/17 12:02:50 error connecting to database or reading migrations
 2019/10/17 12:02:50 dial tcp 127.0.0.1:5432: connect: connection refused
 ```
 
-This is benign can be fixed with the following steps
+If you do, try again in some time.
 
+- To create the first admin account for `m3`
+**Note down the admin access/secret key**
 ```
-kubectl port-forward -n m3 svc/postgres 5432
-```
-
-```
-./m3 setup db
+./m3 admin add "Admin" "admin@email.com"
 ```
 
 ## Creating a new Storage Group

--- a/cluster/setup.go
+++ b/cluster/setup.go
@@ -36,7 +36,7 @@ const (
 )
 
 // Setups m3 on the kubernetes deployment that we are installed to
-func SetupM3(name, email string) error {
+func SetupM3() error {
 	// setup m3 namespace on k8s
 	fmt.Println("Setting up m3 namespace")
 	setupM3Namespace()
@@ -46,19 +46,6 @@ func SetupM3(name, email string) error {
 	// setup database
 	fmt.Println("Setting up postgres")
 	setupPostgres()
-	// Add the first cluster admin
-	fmt.Println("Adding the first admin")
-	admin, err := AddAdmin(name, email)
-	if err != nil {
-		fmt.Println("Error adding user:", err.Error())
-		return err
-	}
-	fmt.Printf("Access Key: %s\n", admin.AccessKey)
-	fmt.Printf("Secret Key: %s\n", admin.SecretKey)
-	fmt.Println("Write these credentials down as this is the only time the secret will be shown.")
-	// run migrations
-	fmt.Println("Running Migrations")
-	RunMigrations()
 	return nil
 }
 
@@ -293,5 +280,20 @@ func CreateTenantsSharedDatabase() error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// Add an m3 admin account with the given name and email
+func AddM3Admin(name, email string) error {
+	// Add the first cluster admin
+	fmt.Println("Adding the first admin")
+	admin, err := AddAdmin(name, email)
+	if err != nil {
+		fmt.Println("Error adding user:", err.Error())
+		return err
+	}
+	fmt.Printf("Access Key: %s\n", admin.AccessKey)
+	fmt.Printf("Secret Key: %s\n", admin.SecretKey)
+	fmt.Println("Write these credentials down as this is the only time the secret will be shown.")
 	return nil
 }

--- a/cmd/m3/setup-db.go
+++ b/cmd/m3/setup-db.go
@@ -26,7 +26,7 @@ import (
 // list files and folders.
 var setupDbCmd = cli.Command{
 	Name:   "db",
-	Usage:  "runs the migrations for the setup db",
+	Usage:  "runs DB migrations",
 	Action: setupDB,
 }
 

--- a/cmd/m3/setup.go
+++ b/cmd/m3/setup.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/minio/cli"
 	"github.com/minio/m3/cluster"
 )
@@ -26,7 +24,7 @@ import (
 // list files and folders.
 var setupCmd = cli.Command{
 	Name:   "setup",
-	Usage:  "Setups the m3 cluster",
+	Usage:  "Creates the m3 cluster",
 	Action: setupDefCmd,
 	Subcommands: []cli.Command{
 		setupDbCmd,
@@ -34,23 +32,5 @@ var setupCmd = cli.Command{
 }
 
 func setupDefCmd(ctx *cli.Context) error {
-	name := ctx.String("name")
-	email := ctx.String("email")
-	if name == "" && ctx.Args().Get(0) != "" {
-		name = ctx.Args().Get(0)
-	}
-	if email == "" && ctx.Args().Get(1) != "" {
-		email = ctx.Args().Get(1)
-	}
-
-	if name == "" {
-		fmt.Println("An admin name is needed")
-		return errMissingArguments
-	}
-
-	if email == "" {
-		fmt.Println("An admin email is needed")
-		return errMissingArguments
-	}
-	return cluster.SetupM3(name, email)
+	return cluster.SetupM3()
 }


### PR DESCRIPTION
Currently, `m3 setup "Admin name" "admin@email.com"` doesn't work unless one has a local postgres server running. This PR makes `./m3 setup ...` commands work with the postgres running inside the kind based kubernetes cluster.