### PR TITLE
validateSessionID func should return sessionRowID and tenantShortname

### DIFF
--- a/portal/api-authentication-grpc.go
+++ b/portal/api-authentication-grpc.go
@@ -136,15 +136,17 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (res *pb.LoginR
 // Logout sets session's status to invalid after validating the sessionId
 func (s *server) Logout(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
 	var (
-		err          error
-		appCtx       *cluster.Context
-		sessionRowID string
+		err             error
+		appCtx          *cluster.Context
+		sessionRowID    string
+		tenantShortname string
 	)
-	if sessionRowID, err = validateSessionID(ctx); err != nil {
+	sessionRowID, tenantShortname, err = validateSessionID(ctx)
+	if err != nil || tenantShortname == "" || sessionRowID == "" {
 		return nil, err
 	}
 
-	appCtx, err = cluster.NewContext("none")
+	appCtx, err = cluster.NewContext(tenantShortname)
 	err = cluster.UpdateSessionStatus(appCtx, sessionRowID, "invalid")
 	if err != nil {
 		appCtx.Rollback()

--- a/portal/utils.go
+++ b/portal/utils.go
@@ -80,15 +80,15 @@ func getSessionRowIDAndTenantName(ctx context.Context) (string, string, error) {
 }
 
 // validateSessionId validates the sessionID available in the grpc metadata
-// headers and returns the session row id
-func validateSessionID(ctx context.Context) (string, error) {
-	sessionRowID, _, err := getSessionRowIDAndTenantName(ctx)
-	return sessionRowID, err
+// headers and returns the session row id and the tenant short name
+func validateSessionID(ctx context.Context) (string, string, error) {
+	sessionRowID, tenantShortname, err := getSessionRowIDAndTenantName(ctx)
+	return sessionRowID, tenantShortname, err
 }
 
 // getTenantShortNameFromSessionID validates the sessionID available in the grpc
 // metadata headers and returns the tenant's shortname
 func getTenantShortNameFromSessionID(ctx context.Context) (string, error) {
-	_, tenantShortname, err := getSessionRowIDAndTenantName(ctx)
+	_, tenantShortname, err := validateSessionID(ctx)
 	return tenantShortname, err
 }


### PR DESCRIPTION
`validateSessionID` func should return sessionRowID and `tenantShortname`, `validateSessionID` is now reused by `getTenantShortNameFromSessionID`.

A harcoded "none" value was preventing the right context creation before invalidating user session