### PR TITLE
CLI Dev Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ MinIO Kubernetes Cloud
 
 - [Docker](https://docs.docker.com/install/)
 
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+A binary release can be downloaded via 
 
 ```
 curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
 ```
 
-- [Kubefwd](https://github.com/txn2/kubefwd)
+- [Kubefwd](https://github.com/txn2/kubefwd) (Optional)
 
 ```
 go get github.com/txn2/kubefwd/cmd/kubefwd
@@ -27,7 +29,7 @@ go get github.com/golang/protobuf/protoc-gen-go
 
 ## Installation
 
-- Install [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/)
+- Install [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
 
 ```
 go get sigs.k8s.io/kind@v0.5.1
@@ -56,19 +58,12 @@ export KUBECONFIG=$(kind get kubeconfig-path --name="m3cluster")
 kubectl proxy
 ```
 
-- Log in to the dashboard at  http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login
+- Log in to the dashboard at `http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login`
 
 - To get the access token
 
-On *nix:
 ```
 kubectl get secret $(kubectl get serviceaccount dashboard -o jsonpath="{.secrets[0].name}") -o jsonpath="{.data.token}" | base64 --decode
-```
-
-On macOS:
-
-```
-kubectl get secret $(kubectl get serviceaccount dashboard -o jsonpath="{.secrets[0].name}") -o jsonpath="{.data.token}" | base64 --decode | pbcopy
 ```
 
 ## Setup `m3`
@@ -80,7 +75,7 @@ kubectl get secret $(kubectl get serviceaccount dashboard -o jsonpath="{.secrets
 make m3
 ```
 
-- Build `m3` local docker image and push it to your k8s
+- Build `m3` local docker image and push it to your local kubernetes
 
 ```
 make k8sdev
@@ -96,10 +91,10 @@ A valid `smtp` account is needed, if you don't have one we recommend you create 
 kubectl apply -f k8s/deployments/m3-deployment.yaml
 ``` 
 
-- Make m3 reachable
+- Start m3 development environment
 
 ```
-kubectl port-forward service/m3 50052
+./m3 dev
 ```
 
 - Run `m3 setup` on the local kubernetes
@@ -187,8 +182,12 @@ or
 
 ## Accessing the tenant MinIO service via browser UI
 
+The nginx router should be exposed on your local on port `9000` after doing `./m3 dev`
+
+Modify your `/etc/hosts` and add the following record
+
 ```
-kubectl port-forward svc/nginx-resolver 1337:80
+127.0.0.1   s3.localhost
 ```
 
-Then in your browser go to: http://company-short-name.s3.localhost:1337/, you can add more tenants and access them via a subdomain in localhost for now.
+Then in your browser go to: http://company-short-name.s3.localhost:9000/, you can add more tenants and access them via a subdomain in localhost for now.

--- a/cmd/m3/dev.go
+++ b/cmd/m3/dev.go
@@ -1,0 +1,273 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+// Development command, will port-forward the public and private interfaces of m3 and the
+var devCmd = cli.Command{
+	Name:   "dev",
+	Usage:  "dev command",
+	Action: dev,
+	Subcommands: []cli.Command{
+		addTenantCmd,
+		tenantBucketCmd,
+		tenantUserCmd,
+		tenantDeleteCmd,
+		tenantServiceAccountCmd,
+	},
+}
+
+func dev(ctx *cli.Context) error {
+	fmt.Println("Starting development environment")
+	kindk8sConf := getKindKubeConf()
+	fmt.Printf("Kind conf `%s`\n", kindk8sConf)
+
+	m3PFCtx, m3Cancel := context.WithCancel(context.Background())
+	nginxCtx, nCancel := context.WithCancel(context.Background())
+	doneCh := make(chan struct{})
+
+	//go func() {
+	//	time.Sleep(time.Second * 10)
+	//	fmt.Println("Simulate cancellation")
+	//	close(doneCh)
+	//	m3Cancel()
+	//}()
+
+	// listen for kill sign to stop all the processes
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		for sig := range c {
+			close(doneCh)
+			m3Cancel()
+			nCancel()
+			fmt.Println("Heard someone want us death x_x", sig)
+		}
+	}()
+	config := &rest.Config{
+		// TODO: switch to using cluster DNS.
+		Host:            "http://localhost:8001",
+		TLSClientConfig: rest.TLSClientConfig{},
+		BearerToken:     "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImRhc2hib2FyZC10b2tlbi1mZ2J4NSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJkYXNoYm9hcmQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiIyNGE3Mjg1OC00YjE4LTRhZDEtYjM4YS03ZTA2NGM2ODI1ZmEiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpkYXNoYm9hcmQifQ.OTj-gB3OnDA5yDmtRZVF9wxMx-6fT1o3vSmd_lZrCpddTBgSkUb2vnaB8eVDQ_DKN2fHsnWw6JvZoPftJ27gKVZ_dAM_21XwgUJy72_lhI_XLinGcx5TAqObxhLp5-YlCTQPDbVEW56DUs59mvx2KKaYeeS7KE-ORYN4wpH6ecZnhUR7_jhSdJAb9MBp3reUU6Iou2YDfEHtHgrSoF7EpZrQME8zjtTQE0Fkl6YavKA1zjHMg-yKuiFRjLkKcrcXyYa_j4lFXL_ZGEICy94FsjGAPv4iwCqZW9ruTU9EX0B0BbG4xGYEZfgG6B5iqIUdleYzHl86eSpWQMS5H5xguQ",
+		BearerTokenFile: "some/file",
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		fmt.Println("ERROR WITH INFORMER")
+	}
+
+	publicCh := servicePortForwardPort(m3PFCtx, kindk8sConf, "m3", "50051", color.FgYellow)
+	privateCh := servicePortForwardPort(m3PFCtx, kindk8sConf, "m3", "50052", color.FgGreen)
+	nginxCh := servicePortForwardPort(nginxCtx, kindk8sConf, "nginx-resolver", "9000:80", color.FgCyan)
+	initialized := false
+	nginxInitialized := false
+
+	// informer factorys
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	// monitor nginx with informer
+	deploymentInformer := factory.Extensions().V1beta1().Deployments().Informer()
+	deploymentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, obj interface{}) {
+			deployment := obj.(*v1beta1.Deployment)
+			if deployment.GetLabels()["app"] == "nginx-resolver" && len(deployment.Status.Conditions) > 0 && deployment.Status.Conditions[0].Status == "True" {
+				fmt.Println("nginx-resolver deployment created correctly")
+				close(nginxCh)
+			}
+		},
+	})
+
+	go deploymentInformer.Run(doneCh)
+
+	// monitor m3 with pod informer
+	podInformer := factory.Core().V1().Pods().Informer()
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			pod := obj.(*v1.Pod)
+			if strings.HasPrefix(pod.ObjectMeta.Name, "m3") {
+				fmt.Println("An m3 pod was added:", pod.ObjectMeta.Name)
+				// we are going to ignore the first registed pod
+				if !initialized {
+					initialized = true
+					fmt.Println("Initialized Pod Informer")
+				} else {
+					// close private and public so they get restarted
+					m3Cancel()
+					// restart the context
+					m3PFCtx, m3Cancel = context.WithCancel(context.Background())
+				}
+			}
+			// monitor nginx
+			if strings.HasPrefix(pod.ObjectMeta.Name, "nginx") {
+				fmt.Println("An nginx pod was added:", pod.ObjectMeta.Name)
+				// we are going to ignore the first registed pod
+				if !nginxInitialized {
+					nginxInitialized = true
+					fmt.Println("Initialized Pod Informer")
+				} else {
+					// close private and public so they get restarted
+					nCancel()
+					// restart the context
+					nginxCtx, nCancel = context.WithCancel(context.Background())
+				}
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			pod := obj.(*v1.Pod)
+			if strings.HasPrefix(pod.ObjectMeta.Name, "m3") {
+				fmt.Println("An m3 pod was deleted:", pod.ObjectMeta.Name)
+			}
+		},
+	})
+
+	go podInformer.Run(doneCh)
+
+	// monitor if a channel gets closed
+	for {
+		select {
+		case <-publicCh:
+			fmt.Println("Public port forward closed, restarting it after 2 seconds")
+			time.Sleep(time.Second * 2)
+			publicCh = servicePortForwardPort(m3PFCtx, kindk8sConf, "m3", "50051", color.BgBlue)
+		case <-privateCh:
+			fmt.Println("Private port forward closed, restarting it after 2 seconds")
+			time.Sleep(time.Second * 2)
+			privateCh = servicePortForwardPort(m3PFCtx, kindk8sConf, "m3", "50052", color.BgGreen)
+		case <-nginxCh:
+			fmt.Println("Nginx port forward closed, restarting it after 2 seconds")
+			time.Sleep(time.Second * 2)
+			nginxCh = servicePortForwardPort(m3PFCtx, kindk8sConf, "nginx-resolver", "9000:80", color.BgCyan)
+		}
+	}
+	// about to exit
+	m3Cancel()
+	nCancel()
+	return nil
+}
+
+// get the current kind config location
+func getKindKubeConf() string {
+	cmd := exec.Command("kind", "get", "kubeconfig-path", "--name=m3cluster")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Fatalf("cmd.Run() failed with %s\n", err)
+	}
+	kindk8sConf := string(out)
+	kindk8sConf = strings.TrimSpace(kindk8sConf)
+	return kindk8sConf
+}
+
+// run the command inside a goroutine, return a channel that closes then the command dies
+func servicePortForwardPort(ctx context.Context, kindk8sConf, service, port string, dcolor color.Attribute) chan interface{} {
+	ch := make(chan interface{})
+	go func() {
+		defer close(ch)
+		// service we are going to forward
+		serviceName := fmt.Sprintf("service/%s", service)
+		// command to run
+		cmd := exec.CommandContext(ctx, "kubectl", "port-forward", serviceName, port)
+		// set the environment variables so kubectl can find the kind configuration
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, fmt.Sprintf("KUBECONFIG=%s", kindk8sConf))
+		// prepare to capture the output
+		var stdout, _ []byte
+		var errStdout, errStderr error
+		stdoutIn, _ := cmd.StdoutPipe()
+		stderrIn, _ := cmd.StderrPipe()
+		err := cmd.Start()
+		if err != nil {
+			log.Fatalf("cmd.Start() failed with '%s'\n", err)
+		}
+
+		// cmd.Wait() should be called only after we finish reading
+		// from stdoutIn and stderrIn.
+		// wg ensures that we finish
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			stdout, errStdout = copyAndCapture(os.Stdout, stdoutIn, dcolor)
+			wg.Done()
+		}()
+
+		_, errStderr = copyAndCapture(os.Stderr, stderrIn, dcolor)
+
+		wg.Wait()
+
+		err = cmd.Wait()
+		if err != nil {
+			log.Println("cmd.Run() failed with %s\n", err)
+			return
+		}
+		if errStdout != nil || errStderr != nil {
+			log.Println("failed to capture stdout or stderr\n")
+			return
+		}
+		//outStr, errStr := string(stdout), string(stderr)
+		//fmt.Printf("\nout:\n%s\nerr:\n%s\n", outStr, errStr)
+	}()
+	return ch
+}
+
+// capture and print the output of the command
+func copyAndCapture(w io.Writer, r io.Reader, dcolor color.Attribute) ([]byte, error) {
+	var out []byte
+	buf := make([]byte, 1024, 1024)
+	for {
+		n, err := r.Read(buf[:])
+		if n > 0 {
+			d := buf[:n]
+			out = append(out, d...)
+			theColor := color.New(dcolor)
+			//_, err := w.Write(d)
+			_, err := theColor.Print(string(d))
+
+			if err != nil {
+				return out, err
+			}
+		}
+		if err != nil {
+			// Read returns io.EOF at the end of file, which is not an error for us
+			if err == io.EOF {
+				err = nil
+			}
+			return out, err
+		}
+	}
+}

--- a/cmd/m3/dev.go
+++ b/cmd/m3/dev.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"k8s.io/api/extensions/v1beta1"
 )
 
 // Development command, will port-forward the public and private interfaces of m3 and the
@@ -102,19 +101,6 @@ func dev(ctx *cli.Context) error {
 
 	// informer factorys
 	factory := informers.NewSharedInformerFactory(clientset, 0)
-	// monitor nginx with informer
-	deploymentInformer := factory.Extensions().V1beta1().Deployments().Informer()
-	deploymentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, obj interface{}) {
-			deployment := obj.(*v1beta1.Deployment)
-			if deployment.GetLabels()["app"] == "nginx-resolver" && len(deployment.Status.Conditions) > 0 && deployment.Status.Conditions[0].Status == "True" {
-				fmt.Println("nginx-resolver deployment created correctly")
-				close(nginxCh)
-			}
-		},
-	})
-
-	go deploymentInformer.Run(doneCh)
 
 	// monitor m3 with pod informer
 	podInformer := factory.Core().V1().Pods().Informer()

--- a/cmd/m3/main.go
+++ b/cmd/m3/main.go
@@ -56,6 +56,7 @@ var appCmds = []cli.Command{
 	signupCmd,
 	loginCmd,
 	setPasswordCmd,
+	devCmd,
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/fatih/color v1.7.0
 	github.com/golang-migrate/migrate/v4 v4.6.2
 	github.com/golang/protobuf v1.3.2
 	github.com/googleapis/gnostic v0.3.1 // indirect


### PR DESCRIPTION
Introduces a Development command called `./m3 dev` which will do the following

1. Start monitoring m3/nginx pods
2. Port forward nginx (80), public api (50051) and private api (50052) 
3. if a pod gets created (nginx redeployed, m3 redeployed) the port-forwards are restarted

We could potentially also add postgres port-forwarding by default