### PR TITLE
Set m3 target in Makefile as phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ swagger-def:
 	@echo "Generating swagger-def stubs"
 	@protoc -I=protos --swagger_out=logtostderr=true:. protos/public_api.proto
 
+.PHONY: m3
 m3:
 	@echo "Building m3 binary to './m3'"
 	@(cd cmd/m3; CGO_ENABLED=0 go build --ldflags "-s -w" -o ../../m3)


### PR DESCRIPTION
As we have the binary which is named as m3 in the main directory, the
target named m3 is not working properly and returns the message saying
'make: m3 is up to date'. Therefore, we would need to declare the m3
target in the Makefile as phony to avoid this error by force rebuilding
even when a file named m3 is present in the directory.