### PR TITLE
kind6-dev - changes in kind 0.6 was preventing dev script to run

### DIFF
--- a/cmd/m3/dev.go
+++ b/cmd/m3/dev.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"os/user"
 	"strings"
 	"sync"
 	"time"
@@ -172,12 +173,11 @@ OuterLoop:
 
 // get the current kind config location
 func getKindKubeConf() string {
-	cmd := exec.Command("kind", "get", "kubeconfig-path", "--name=m3cluster")
-	out, err := cmd.CombinedOutput()
+	user, err := user.Current()
 	if err != nil {
-		log.Fatalf("cmd.Run() failed with %s\n", err)
+		panic(err)
 	}
-	kindk8sConf := string(out)
+	kindk8sConf := user.HomeDir + "/.kube/kind-config-m3cluster"
 	kindk8sConf = strings.TrimSpace(kindk8sConf)
 	return kindk8sConf
 }


### PR DESCRIPTION
The **kind get kubeconfig-path** command has been deprecated, that was preventing dev to compute the correct config pat.

https://github.com/kubernetes-sigs/kind/issues/1060

We are fixing this issue using the recommended way:

### Emulating The Old Behavior
You can emulate the previous behavior by switching from:

```
kind create cluster --name=foo
export KUBECONFIG="$(kind get kubeconfig-path --name=foo)"
```
to:

```
export KUBECONFIG="${HOME}/.kube/kind-config-foo"
kind create cluster --name=foo
```