### PR TITLE
Fix Tenant Get Config Bug

### DIFF
--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -62,7 +62,7 @@ func createUserCredentials(ctx *Context, tenantShortName string, userdID uuid.UU
 	}
 
 	// Get the credentials for a tenant
-	tenantConf, err := GetTenantConfig(sgt.Tenant.Name)
+	tenantConf, err := GetTenantConfig(sgt.Tenant)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func createServiceAccountCredentials(ctx *Context, tenantShortName string, servi
 	}
 
 	// Get the credentials for a tenant
-	tenantConf, err := GetTenantConfig(sgt.Tenant.Name)
+	tenantConf, err := GetTenantConfig(sgt.Tenant)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/tenants.go
+++ b/cluster/tenants.go
@@ -358,7 +358,7 @@ func newTenantMinioClient(tenantShortname string) (*minio.Client, error) {
 	}
 
 	// Get the credentials for a tenant
-	tenantConf, err := GetTenantConfig(sgt.Tenant.ShortName)
+	tenantConf, err := GetTenantConfig(sgt.Tenant)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/utils.go
+++ b/cluster/utils.go
@@ -61,13 +61,13 @@ func RandomCharString(n int) string {
 }
 
 // GetTenantConfig returns the access/secret keys for a given tenant
-func GetTenantConfig(shortName string) (*TenantConfiguration, error) {
+func GetTenantConfig(tenant *Tenant) (*TenantConfiguration, error) {
 	clientset, err := k8sClient()
 	if err != nil {
 		return nil, err
 	}
 	// Get the tenant main secret
-	tenantSecretName := fmt.Sprintf("%s-env", shortName)
+	tenantSecretName := fmt.Sprintf("%s-env", tenant.ShortName)
 	mainSecret, err := clientset.CoreV1().Secrets("default").Get(tenantSecretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/cmd/m3/dev.go
+++ b/cmd/m3/dev.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"os/user"
 	"strings"
 	"sync"
 	"time"
@@ -160,17 +159,6 @@ OuterLoop:
 	}
 	// about to exit
 	return nil
-}
-
-// get the current kind config location
-func getKindKubeConf() string {
-	user, err := user.Current()
-	if err != nil {
-		panic(err)
-	}
-	kindk8sConf := user.HomeDir + "/.kube/kind-config-m3cluster"
-	kindk8sConf = strings.TrimSpace(kindk8sConf)
-	return kindk8sConf
 }
 
 // run the command inside a goroutine, return a channel that closes then the command dies

--- a/cmd/m3/dev.go
+++ b/cmd/m3/dev.go
@@ -191,9 +191,6 @@ func servicePortForwardPort(ctx context.Context, kindk8sConf, service, port stri
 		serviceName := fmt.Sprintf("service/%s", service)
 		// command to run
 		cmd := exec.CommandContext(ctx, "kubectl", "port-forward", serviceName, port)
-		// set the environment variables so kubectl can find the kind configuration
-		cmd.Env = os.Environ()
-		cmd.Env = append(cmd.Env, fmt.Sprintf("KUBECONFIG=%s", kindk8sConf))
 		// prepare to capture the output
 		var errStdout, errStderr error
 		stdoutIn, _ := cmd.StdoutPipe()


### PR DESCRIPTION
Fixes a bug where if you were adding a tenant named `Acme` with shortname `acme` an error would show indicating the `Acme-env` did not exist