### PR TITLE
Update  m3 to latest minio release

### DIFF
--- a/cluster/minio-tenant.go
+++ b/cluster/minio-tenant.go
@@ -51,9 +51,8 @@ func mkTenantMinioContainer(sgTenant *StorageGroupTenant, sgNode *StorageGroupNo
 	}
 
 	tenantContainer := v1.Container{
-		Name:  fmt.Sprintf("%s-minio-%d", sgTenant.Tenant.ShortName, sgNode.Num),
-		Image: "minio/minio:RELEASE.2019-12-17T23-16-33Z",
-		//Image:           "minio/minio:latest",
+		Name:            fmt.Sprintf("%s-minio-%d", sgTenant.Tenant.ShortName, sgNode.Num),
+		Image:           "minio/minio:RELEASE.2019-12-19T22-52-26Z",
 		ImagePullPolicy: "Always",
 		Args:            minioConfigCmd,
 		Ports: []v1.ContainerPort{

--- a/cluster/tenants.go
+++ b/cluster/tenants.go
@@ -699,6 +699,8 @@ func createTenantConfigMap(sgTenant *StorageGroupTenant) error {
 		tenantConfig["MINIO_ETCD_ENDPOINTS"] = "http://m3-etcd-cluster-client:2379"
 		tenantConfig["MINIO_ETCD_PATH_PREFIX"] = fmt.Sprintf("%s/", sgTenant.Tenant.ShortName)
 	}
+	// Env variable to tell MinIO that it is running on a replica set deployment
+	tenantConfig["KUBERNETES_REPLICA_SET"] = "1"
 	// Build the config map
 	configMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/k8s/create-kind.sh
+++ b/k8s/create-kind.sh
@@ -8,11 +8,11 @@ echo "creating service account"
 kubectl create serviceaccount dashboard -n default
 kubectl create clusterrolebinding dashboard-admin -n default --clusterrole=cluster-admin --serviceaccount=default:dashboard
 # pre-load MinIO, postgres, etcd, etcd-operator to speed up setup
-docker pull minio/minio:RELEASE.2019-12-17T23-16-33Z
+docker pull minio/minio:RELEASE.2019-12-19T22-52-26Z
 docker pull postgres:12
 docker pull quay.io/coreos/etcd-operator:v0.9.4
 docker pull quay.io/coreos/etcd:v3.4.0
-kind load docker-image minio/minio:RELEASE.2019-12-17T23-16-33Z --name m3cluster
+kind load docker-image minio/minio:RELEASE.2019-12-19T22-52-26Z --name m3cluster
 kind load docker-image postgres:12 --name m3cluster
 kind load docker-image quay.io/coreos/etcd-operator:v0.9.4 --name m3cluster
 kind load docker-image quay.io/coreos/etcd:v3.4.0 --name m3cluster


### PR DESCRIPTION
This is necessary for global bucket support. And it fixes some issues on MinIO running on replica set deployment.