### PR TITLE
Remove defer close in loops to avoid confusion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,3 @@ linters:
     - deadcode
     - unparam
     - structcheck
-
-service:
-  golangci-lint-version: 1.20.0 # use the fixed version to not introduce new linters unexpectedly

--- a/cluster/service-accounts.go
+++ b/cluster/service-accounts.go
@@ -697,7 +697,6 @@ func streamAccessKeyToTenantServices() chan *AccessKeyToTenantShortNameResult {
 				ch <- &AccessKeyToTenantShortNameResult{Error: err}
 				return
 			}
-			defer rows.Close()
 
 			for rows.Next() {
 				// Save the resulted query on the User struct
@@ -707,6 +706,7 @@ func streamAccessKeyToTenantServices() chan *AccessKeyToTenantShortNameResult {
 				err = rows.Scan(&ak2s.AccessKey)
 				if err != nil {
 					ch <- &AccessKeyToTenantShortNameResult{Error: err}
+					rows.Close()
 					return
 				}
 				ch <- &AccessKeyToTenantShortNameResult{AccessKeyToTenantShortName: &ak2s}
@@ -715,9 +715,11 @@ func streamAccessKeyToTenantServices() chan *AccessKeyToTenantShortNameResult {
 			err = rows.Err()
 			if err != nil {
 				ch <- &AccessKeyToTenantShortNameResult{Error: err}
+				rows.Close()
 				return
 			}
 
+			rows.Close()
 		}
 	}()
 	return ch


### PR DESCRIPTION
Defers in range loops may not run when you expect
them to, in our scenario these defers are not closed
until the channel is closed.