### PR TITLE
Task Scheduler

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -36,9 +36,9 @@ func getS3Domain() string {
 }
 
 func getM3ContainerImage() string {
-	m3Image := "minio/m3:dev"
+	concreteM3Image := "minio/m3:dev"
 	if os.Getenv(m3Image) != "" {
-		m3Image = os.Getenv(m3Image)
+		concreteM3Image = os.Getenv(m3Image)
 	}
-	return m3Image
+	return concreteM3Image
 }

--- a/cluster/const.go
+++ b/cluster/const.go
@@ -27,6 +27,7 @@ const (
 	secretKey            = "SECRET_KEY"
 	maxTenantChannelSize = "MAX_TENANT_CHANNEL_SIZE"
 	s3Domain             = "S3_DOMAIN"
+	m3Image              = "M3_IMAGE"
 	// constants
 	TokenSignupEmail            = "signup-email"
 	TokenResetPasswordEmail     = "reset-password-email"

--- a/cluster/migrations/000010_tasks.down.sql
+++ b/cluster/migrations/000010_tasks.down.sql
@@ -1,0 +1,17 @@
+-- This file is part of MinIO Kubernetes Cloud
+-- Copyright (c) 2019 MinIO, Inc.
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+DROP TABLE tasks;

--- a/cluster/migrations/000010_tasks.up.sql
+++ b/cluster/migrations/000010_tasks.up.sql
@@ -1,0 +1,39 @@
+-- This file is part of MinIO Kubernetes Cloud
+-- Copyright (c) 2019 MinIO, Inc.
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+CREATE TABLE tasks
+(
+    id               SERIAL                                                    NOT NULL
+        CONSTRAINT tasks_pk
+            PRIMARY KEY,
+    name             VARCHAR(256),
+    status           VARCHAR                  DEFAULT 'new'::CHARACTER VARYING NOT NULL,
+    data             JSONB,
+    sys_created_date TIMESTAMP WITH TIME ZONE DEFAULT now(),
+    sys_updated_date TIMESTAMP WITH TIME ZONE,
+    scheduled_time   TIMESTAMP WITH TIME ZONE
+);
+
+COMMENT ON COLUMN tasks.name IS 'name of the task that is scheduled';
+
+COMMENT ON COLUMN tasks.data IS 'data to pass to the task';
+
+COMMENT ON COLUMN tasks.scheduled_time IS 'time when the task was scheduled';
+
+CREATE INDEX tasks_status_index
+    ON tasks (status);
+

--- a/cluster/scheduler.go
+++ b/cluster/scheduler.go
@@ -1,0 +1,253 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cluster
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type TaskStatus string
+
+const (
+	NewTaskStatus             TaskStatus = "new"
+	ScheduledTaskStatus                  = "scheduled"
+	CompleteTaskStatus                   = "complete"
+	ErrorSchedulingTaskStatus            = "error_scheduling"
+	FailedTaskStatus                     = "failed"
+	StalledTaskStatus                    = "stalled"
+	UnknownTaskStatus                    = "unknown"
+)
+
+const (
+	failTask  = "fail"
+	emptyTask = "empty"
+)
+
+type Task struct {
+	ID     int64
+	Name   string
+	Status TaskStatus
+	// json representation of the data
+	Data []byte
+}
+
+// starts a loop that monitors the tasks table for pending task to schedule inside the cluster
+func StartScheduler() {
+	// monitor tasks table for new tasks every 500ms
+	for {
+		task, err := fetchNewTask()
+		if err != nil && err != sql.ErrNoRows {
+			// panic if we can't fetch tasks
+			panic(err)
+		}
+		// if we got a task, schedule it
+		if task != nil {
+			log.Printf("Schedule task %d\n", task.ID)
+			if err := scheduleTask(task); err != nil {
+				log.Println(err)
+				if err = markTask(task, ErrorSchedulingTaskStatus); err != nil {
+					log.Println(err)
+				}
+			}
+		} else {
+			// we got not task, sleep a little
+			time.Sleep(time.Millisecond * 500)
+		}
+	}
+}
+
+// fetchNewTask gets a task in "new" state and locks it until it's unlocked by an update to the record.
+// We do the locking at database just in case there's 2 schedulers running, they cannot grab the same task.
+func fetchNewTask() (*Task, error) {
+	// select a task in new state and lock it
+	query :=
+		`SELECT 
+				t.id, t.name, t.data, t.status
+			FROM 
+				tasks t
+			WHERE t.status=$1
+			LIMIT 1
+		FOR UPDATE`
+	// query the reord
+	row := GetInstance().Db.QueryRow(query, NewTaskStatus)
+	task := Task{}
+	// Save the resulted query on the User struct
+	err := row.Scan(&task.ID, &task.Name, &task.Data, &task.Status)
+	if err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+// markTask marks a task as the passes `newStatus` state.
+func markTask(task *Task, newStatus TaskStatus) error {
+	// if we are marking the task as scheduled, set the schedule time field
+	extraField := ""
+	if newStatus == ScheduledTaskStatus {
+		extraField = ", scheduled_time = now()"
+	}
+	// build the query
+	query := fmt.Sprintf(
+		`UPDATE tasks 
+					SET status = $1 %s
+				WHERE id=$2`, extraField)
+
+	// Execute Query
+	_, err := GetInstance().Db.Exec(query, newStatus, task.ID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// scheduleTask creates the kubernetes job for the passed task and if successful, it marks the task as scheduled
+func scheduleTask(task *Task) error {
+	// create job
+	err := startJob(task)
+	if err != nil {
+		log.Println(err)
+		if err = markTask(task, ErrorSchedulingTaskStatus); err != nil {
+			log.Println(err)
+		}
+		return err
+	}
+	// mark the task as scheduled
+	if err = markTask(task, ScheduledTaskStatus); err != nil {
+		return err
+	}
+	return nil
+}
+
+// startJob starts a kubernets job for the passed task
+func startJob(task *Task) error {
+	var backoff int32 = 0
+	var ttlJob int32 = 60
+	job := batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Job",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("task-%d-%s-job", task.ID, task.Name),
+		},
+		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: &ttlJob,
+			BackoffLimit:            &backoff,
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Volumes: nil,
+					Containers: []v1.Container{
+						{
+							Name:  "task",
+							Image: getM3ContainerImage(),
+							Command: []string{
+								"/m3",
+								"run-task",
+								fmt.Sprintf("%d", task.ID),
+							},
+							ImagePullPolicy: "IfNotPresent",
+							EnvFrom: []v1.EnvFromSource{
+								{
+									ConfigMapRef: &v1.ConfigMapEnvSource{
+										LocalObjectReference: v1.LocalObjectReference{Name: "m3-env"},
+									},
+								},
+							},
+						},
+					},
+					RestartPolicy: "Never",
+					// TODO: Select only application nodes
+				},
+			},
+		},
+	}
+	// schedule job in k8s
+	clientset, err := k8sClient()
+	if err != nil {
+		return err
+	}
+	_, err = clientset.BatchV1().Jobs(defNS).Create(&job)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// getTaskById returns a task by id
+func getTaskById(id int64) (*Task, error) {
+	query :=
+		`SELECT 
+				t.id, t.name, t.data, t.status
+			FROM 
+				tasks t
+			WHERE t.id=$1
+			LIMIT 1`
+	// query the reord
+	row := GetInstance().Db.QueryRow(query, id)
+	task := Task{}
+	// Save the resulted query on the User struct
+	err := row.Scan(&task.ID, &task.Name, &task.Data, &task.Status)
+	if err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+// RunTask runs a task by id and records the result of if on the task record.
+// attempts to recover from a panic in case there's one within the task and also marks it on the db.
+func RunTask(id int64) error {
+	task, err := getTaskById(id)
+	if err != nil {
+		return err
+	}
+	// if the task fails, mark it as such
+	defer func() {
+		if err := recover(); err != nil {
+			log.Println(err)
+			if err := markTask(task, FailedTaskStatus); err != nil {
+				log.Println(err)
+			}
+			time.Sleep(time.Second * 2)
+			os.Exit(1)
+		}
+	}()
+	// check whether the task name is a registered task name or not
+	switch task.Name {
+	case failTask:
+		panic("Intentional Task Failure")
+	case emptyTask:
+		log.Println("Empty Task")
+	default:
+		log.Printf("Unknown task name: %s\n", task.Name)
+		if err := markTask(task, UnknownTaskStatus); err != nil {
+			log.Println(err)
+		}
+	}
+	// mark the task as complete
+	if err = markTask(task, CompleteTaskStatus); err != nil {
+		return err
+	}
+	os.Exit(0)
+	return nil
+}

--- a/cluster/scheduler.go
+++ b/cluster/scheduler.go
@@ -194,8 +194,8 @@ func startJob(task *Task) error {
 	return nil
 }
 
-// getTaskById returns a task by id
-func getTaskById(id int64) (*Task, error) {
+// getTaskByID returns a task by id
+func getTaskByID(id int64) (*Task, error) {
 	query :=
 		`SELECT 
 				t.id, t.name, t.data, t.status
@@ -217,7 +217,7 @@ func getTaskById(id int64) (*Task, error) {
 // RunTask runs a task by id and records the result of if on the task record.
 // attempts to recover from a panic in case there's one within the task and also marks it on the db.
 func RunTask(id int64) error {
-	task, err := getTaskById(id)
+	task, err := getTaskByID(id)
 	if err != nil {
 		return err
 	}

--- a/cmd/m3/main.go
+++ b/cmd/m3/main.go
@@ -59,6 +59,8 @@ var appCmds = []cli.Command{
 	devCmd,
 	portalCmd,
 	emailTemplateCmd,
+	schedulerCmd,
+	runTaskCmd,
 }
 
 func main() {

--- a/cmd/m3/run-task.go
+++ b/cmd/m3/run-task.go
@@ -1,0 +1,57 @@
+// This file is part of MinIO Kubernetes Cloud
+// Copyright (c) 2019 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"log"
+	"strconv"
+
+	"github.com/minio/cli"
+	"github.com/minio/m3/cluster"
+)
+
+// runs a task
+var runTaskCmd = cli.Command{
+	Name:   "run-task",
+	Usage:  "runs the provided task and reports on wether it succeeded or failed",
+	Action: runTask,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "id",
+			Value: "",
+			Usage: "ID of the task to execute",
+		},
+	},
+}
+
+func runTask(ctx *cli.Context) error {
+	id := ctx.Int64("id")
+	if id == 0 && ctx.Args().Get(0) != "" {
+		var err error
+		id, err = strconv.ParseInt(ctx.Args().Get(0), 10, 64)
+		if err != nil {
+			return errors.New("invalid error identifier")
+		}
+	}
+	log.Printf("Runnnig task: %d\n", id)
+	if err := cluster.RunTask(id); err != nil {
+		log.Println(err)
+		return err
+	}
+	return nil
+}

--- a/cmd/m3/scheduler.go
+++ b/cmd/m3/scheduler.go
@@ -14,31 +14,35 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package cluster
+package main
 
-import "os"
+import (
+	"log"
+	"time"
 
-// hostConfig configuration of a host.
-type hostConfigV9 struct {
-	URL       string `json:"url"`
-	AccessKey string `json:"accessKey"`
-	SecretKey string `json:"secretKey"`
-	API       string `json:"api"`
-	Lookup    string `json:"lookup"`
+	"github.com/minio/m3/cluster"
+
+	"github.com/minio/cli"
+)
+
+// start the binary as a scheduler
+var schedulerCmd = cli.Command{
+	Name:   "scheduler",
+	Usage:  "starts m3 scheduler which starts async jobs",
+	Action: startSchedulerCmd,
 }
 
-func getS3Domain() string {
-	appDomain := "s3.localhost"
-	if os.Getenv(s3Domain) != "" {
-		appDomain = os.Getenv(s3Domain)
+func startSchedulerCmd(ctx *cli.Context) error {
+	setupComplete, err := cluster.IsSetupComplete()
+	if err != nil {
+		log.Println("problem checking on the setup of m3")
 	}
-	return appDomain
-}
-
-func getM3ContainerImage() string {
-	m3Image := "minio/m3:dev"
-	if os.Getenv(m3Image) != "" {
-		m3Image = os.Getenv(m3Image)
+	if !setupComplete {
+		log.Println("m3 is not setup yet, will sleep and then crash peacefully")
+		time.Sleep(time.Second * 30)
+		panic("Good bye")
 	}
-	return m3Image
+	log.Println("Starting m3 scheduler...")
+	cluster.StartScheduler()
+	return nil
 }

--- a/cmd/m3/tenant-permission-assign.go
+++ b/cmd/m3/tenant-permission-assign.go
@@ -38,7 +38,7 @@ var assignPermissionCmd = cli.Command{
 		cli.StringFlag{
 			Name:  "permission",
 			Value: "",
-			Usage: "Id of the permission",
+			Usage: "ID of the permission",
 		},
 		cli.StringFlag{
 			Name:  "service-accounts",

--- a/k8s/deployments/m3-deployment.yaml.example
+++ b/k8s/deployments/m3-deployment.yaml.example
@@ -33,6 +33,26 @@ spec:
   selector:
     app: m3
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: m3-env
+data:
+  ADMIN_NAME: <ADMIN_NAME>
+  ADMIN_EMAIL: <ADMIN_EMAIL>
+  DB_HOSTNAME: "postgres.m3"
+  MAIL_ACCOUNT: <MAIL_ACCOUNT>
+  MAIL_SERVER: <MAIL_SERVER>
+  MAIL_PASSWORD: <MAIL_PASSWORD>
+  APP_URL: <APP_URL>
+  S3_DOMAIN: <S3_DOMAIN>
+  SETUP_USE_GLOBAL_BUCKETS: "true"
+  # Uncomment these to enable IDP for Admin Login
+  #IDENTITY_PROVIDER_URL: ""
+  #IDENTITY_PROVIDER_CLIENT_ID: ""
+  #IDENTITY_PROVIDER_SECRET: ""
+  #IDENTITY_PROVIDER_CALLBACK: ""
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,36 +75,37 @@ spec:
           args:
             - /m3
             - service
-          env:
-          # Uncomment these to enable IDP for Admin Login
-#            - name: IDENTITY_PROVIDER_URL
-#              value: ""
-#            - name: IDENTITY_PROVIDER_CLIENT_ID
-#              value: ""
-#            - name: IDENTITY_PROVIDER_SECRET
-#              value: ""
-#            - name: IDENTITY_PROVIDER_CALLBACK
-#              value: ""
-            - name: ADMIN_NAME
-              value: "<ADMIN_NAME>"
-            - name: ADMIN_EMAIL
-              value: "<ADMIN_EMAIL>"
-            - name: DB_HOSTNAME
-              value: postgres.m3
-            - name: MAIL_ACCOUNT
-              value: "<DEV_EMAIL_ACCOUNT>"
-            - name: MAIL_SERVER
-              value: "<DEV_EMAIL_SERVER>"
-            - name: MAIL_PASSWORD
-              value: "<DEV_EMAIL_PASSWORD>"
-            - name: APP_URL
-              value: <APP_ADDRESS>
-            - name: S3_DOMAIN
-              value: <YOUR_DOMAIN>
-            - name: SETUP_USE_GLOBAL_BUCKETS
-              value: "true"
+          envFrom:
+              - configMapRef:
+                  name: m3-env
           ports:
             - containerPort: 50051
               name: public-grpc
             - containerPort: 50052
               name: private-grpc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: m3-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: m3-scheduler
+  template:
+    metadata:
+      labels:
+        app: m3-scheduler
+    spec:
+      serviceAccountName: m3-user
+      containers:
+        - name: m3
+          image: minio/m3:dev
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - /m3
+            - scheduler
+          envFrom:
+            - configMapRef:
+                name: m3-env


### PR DESCRIPTION
Task Scheduler is designed to schedule jobs on the kubernetes cluster using jobs. This is intended for long running jobs such as provisioning a new tenant.

A new deployment `m3-scheduler` is added to the example `m3-deployment` so update your local file accordingly, this is because of the new configMap for environment variables `m3-env` which is shared among `m3`, `m3-scheduler` and all the scheduled jobs that run inside `m3`

So this PR can be reviewed while I finish the pre-provisioning of tenants I only added 2 tasks that can be scheduled, `fail` and `empty`, one fails and one suceeds properly.