### PR TITLE
Pre-Provision Tenants

### DIFF
--- a/api/api-private-cluster.go
+++ b/api/api-private-cluster.go
@@ -119,5 +119,15 @@ func (ps *privateServer) ClusterStorageGroupAdd(ctx context.Context, in *pb.Stor
 		log.Println(err)
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
+	// we can tolerate this call failing
+	if err = cluster.SchedulePreProvisionTenantInStorageGroup(appCtx, storageGroupResult.StorageGroup); err != nil {
+		log.Println("Warning:", err)
+	}
+	// Second commit, if the schedule worked fine
+	if err = appCtx.Commit(); err != nil {
+		log.Println(err)
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
+
 	return &pb.StorageGroupAddResponse{}, nil
 }

--- a/api/api-private-tenant-bucket.go
+++ b/api/api-private-tenant-bucket.go
@@ -45,7 +45,7 @@ func (ps *privateServer) TenantBucketAdd(ctx context.Context, in *pb.TenantBucke
 		return nil, status.New(codes.Internal, "Internal Error").Err()
 	}
 	// validate tenant
-	tenant, err := cluster.GetTenant(in.Tenant)
+	tenant, err := cluster.GetTenantByDomain(in.Tenant)
 	if err != nil {
 		log.Println(err)
 		return nil, err

--- a/api/api-private-tenant-permissions.go
+++ b/api/api-private-tenant-permissions.go
@@ -50,7 +50,7 @@ func (ps *privateServer) TenantPermissionAdd(ctx context.Context, in *pb.TenantP
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 	// validate Tenant
-	tenant, err := cluster.GetTenant(in.Tenant)
+	tenant, err := cluster.GetTenantByDomain(in.Tenant)
 	if err != nil {
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
 	}
@@ -74,7 +74,7 @@ func (ps *privateServer) TenantPermissionList(ctx context.Context, in *pb.Tenant
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 	// validate Tenant
-	tenant, err := cluster.GetTenant(in.Tenant)
+	tenant, err := cluster.GetTenantByDomain(in.Tenant)
 	if err != nil {
 		log.Println(err)
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
@@ -128,7 +128,7 @@ func (ps *privateServer) TenantPermissionAssign(ctx context.Context, in *pb.Tena
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 	// validate Tenant
-	tenant, err := cluster.GetTenant(in.Tenant)
+	tenant, err := cluster.GetTenantByDomain(in.Tenant)
 	if err != nil {
 		log.Println(err)
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()

--- a/api/api-private-tenant-service-account.go
+++ b/api/api-private-tenant-service-account.go
@@ -89,7 +89,7 @@ func (ps *privateServer) TenantServiceAccountAssign(ctx context.Context, in *pb.
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 	// validate Tenant
-	tenant, err := cluster.GetTenant(in.Tenant)
+	tenant, err := cluster.GetTenantByDomain(in.Tenant)
 	if err != nil {
 		log.Println(err)
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()

--- a/api/api-private-tenant-user.go
+++ b/api/api-private-tenant-user.go
@@ -53,7 +53,7 @@ func (ps *privateServer) TenantUserAdd(ctx context.Context, in *pb.TenantUserAdd
 		log.Println(err)
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
-	tenant, err := cluster.GetTenant(in.Tenant)
+	tenant, err := cluster.GetTenantByDomain(in.Tenant)
 	if err != nil {
 		log.Println(err)
 		return nil, status.New(codes.NotFound, "Tenant not found").Err()
@@ -110,7 +110,7 @@ func (ps *privateServer) TenantUserDelete(ctx context.Context, in *pb.TenantUser
 		err = appCtx.Commit()
 	}()
 
-	tenant, err := cluster.GetTenant(tenantReq)
+	tenant, err := cluster.GetTenantByDomain(tenantReq)
 	if err != nil {
 		log.Println(err)
 		return nil, status.New(codes.NotFound, "Tenant not found").Err()
@@ -139,7 +139,7 @@ func (ps *privateServer) TenantUserForgotPassword(ctx context.Context, in *pb.Te
 		return nil, status.New(codes.InvalidArgument, "User email is needed").Err()
 	}
 	// validate tenant
-	tenant, err := cluster.GetTenant(in.Tenant)
+	tenant, err := cluster.GetTenantByDomain(in.Tenant)
 	if err != nil {
 		log.Println(err)
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant").Err()

--- a/api/api-public-authentication-grpc.go
+++ b/api/api-public-authentication-grpc.go
@@ -127,7 +127,7 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (res *pb.LoginR
 	email := in.GetEmail()
 
 	// Search for the tenant on the database
-	tenant, err := cluster.GetTenant(tenantName)
+	tenant, err := cluster.GetTenantByDomain(tenantName)
 	if err != nil {
 		return nil, status.New(codes.InvalidArgument, "tenant not valid").Err()
 	}

--- a/cluster/buckets.go
+++ b/cluster/buckets.go
@@ -547,7 +547,7 @@ func CalculateTenantsMetrics() error {
 
 func getTenantMetrics(ctx *Context, tenantShortName string) error {
 	// validate Tenant
-	tenant, err := GetTenant(tenantShortName)
+	tenant, err := GetTenantByDomain(tenantShortName)
 	if err != nil {
 		return err
 	}

--- a/cluster/const.go
+++ b/cluster/const.go
@@ -40,6 +40,7 @@ const (
 	SessionIDKey            key = iota
 	WhoAmIKey               key = iota
 	maxReadinessTries           = 120 // This should allow for 4 minutes of attempts
+	maxNumberOfTenantsPerSg     = 16
 
 	// configurations
 	cfgCoreGlobalBuckets = "core.global_buckets"

--- a/cluster/migrations/000011_pre-alloc-tenants.down.sql
+++ b/cluster/migrations/000011_pre-alloc-tenants.down.sql
@@ -1,0 +1,19 @@
+-- This file is part of MinIO Kubernetes Cloud
+-- Copyright (c) 2019 MinIO, Inc.
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ALTER TABLE tenants
+    DROP COLUMN available;
+

--- a/cluster/migrations/000011_pre-alloc-tenants.up.sql
+++ b/cluster/migrations/000011_pre-alloc-tenants.up.sql
@@ -1,0 +1,28 @@
+-- This file is part of MinIO Kubernetes Cloud
+-- Copyright (c) 2019 MinIO, Inc.
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ALTER TABLE tenants
+    ADD available BOOL DEFAULT FALSE;
+
+COMMENT ON COLUMN tenants.available IS 'wether this pre-allocated tenant is up for grabs';
+
+ALTER TABLE tenants
+    ADD domain VARCHAR(256) NOT NULL;
+
+CREATE UNIQUE INDEX tenants_domain_uindex
+    ON tenants (domain);
+

--- a/cluster/nginx.go
+++ b/cluster/nginx.go
@@ -47,25 +47,6 @@ func getNewNginxDeployment(deploymentName string) appsv1.Deployment {
 						ContainerPort: 80,
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      NginxConfiguration,
-						MountPath: "/etc/nginx/nginx.conf",
-						SubPath:   "nginx.conf",
-					},
-				},
-			},
-		},
-		Volumes: []corev1.Volume{
-			{
-				Name: NginxConfiguration,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: NginxConfiguration,
-						},
-					},
-				},
 			},
 		},
 	}
@@ -324,7 +305,7 @@ func getLocalBucketNamespaceConfiguration(ctx *Context) string {
 					}
 				}
 
-			`, tenantRoute.ShortName, appDomain, tenantRoute.ServiceName, tenantRoute.Port)
+			`, tenantRoute.Domain, appDomain, tenantRoute.ServiceName, tenantRoute.Port)
 		nginxConfiguration.WriteString(serverBlock)
 	}
 	nginxConfiguration.WriteString(`

--- a/cluster/scheduler.go
+++ b/cluster/scheduler.go
@@ -260,7 +260,7 @@ func RunTask(id int64) error {
 }
 
 func ScheduleTask(ctx *Context, name string, data interface{}) error {
-	dataJson, err := json.Marshal(data)
+	dataJSON, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
@@ -275,7 +275,7 @@ func ScheduleTask(ctx *Context, name string, data interface{}) error {
 		return err
 	}
 	// Execute query
-	_, err = tx.Exec(query, name, string(dataJson))
+	_, err = tx.Exec(query, name, string(dataJSON))
 	if err != nil {
 		return err
 	}

--- a/cluster/scheduler.go
+++ b/cluster/scheduler.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -41,8 +42,9 @@ const (
 )
 
 const (
-	failTask  = "fail"
-	emptyTask = "empty"
+	failTask            = "fail"
+	emptyTask           = "empty"
+	TaskProvisionTenant = "provision-tenant"
 )
 
 type Task struct {
@@ -65,7 +67,7 @@ func StartScheduler() {
 		// if we got a task, schedule it
 		if task != nil {
 			log.Printf("Schedule task %d\n", task.ID)
-			if err := scheduleTask(task); err != nil {
+			if err := scheduleTaskJob(task); err != nil {
 				log.Println(err)
 				if err = markTask(task, ErrorSchedulingTaskStatus); err != nil {
 					log.Println(err)
@@ -122,8 +124,8 @@ func markTask(task *Task, newStatus TaskStatus) error {
 	return nil
 }
 
-// scheduleTask creates the kubernetes job for the passed task and if successful, it marks the task as scheduled
-func scheduleTask(task *Task) error {
+// scheduleTaskJob creates the kubernetes job for the passed task and if successful, it marks the task as scheduled
+func scheduleTaskJob(task *Task) error {
 	// create job
 	err := startJob(task)
 	if err != nil {
@@ -144,6 +146,7 @@ func scheduleTask(task *Task) error {
 func startJob(task *Task) error {
 	var backoff int32 = 0
 	var ttlJob int32 = 60
+	log.Println("Scheduling job:", fmt.Sprintf("task-%d-%s-job", task.ID, task.Name))
 	job := batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Job",
@@ -156,7 +159,7 @@ func startJob(task *Task) error {
 			BackoffLimit:            &backoff,
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
-					Volumes: nil,
+					ServiceAccountName: "m3-user",
 					Containers: []v1.Container{
 						{
 							Name:  "task",
@@ -238,6 +241,10 @@ func RunTask(id int64) error {
 		panic("Intentional Task Failure")
 	case emptyTask:
 		log.Println("Empty Task")
+	case TaskProvisionTenant:
+		if err := ProvisionTenantTask(task); err != nil {
+			panic(err)
+		}
 	default:
 		log.Printf("Unknown task name: %s\n", task.Name)
 		if err := markTask(task, UnknownTaskStatus); err != nil {
@@ -250,4 +257,28 @@ func RunTask(id int64) error {
 	}
 	os.Exit(0)
 	return nil
+}
+
+func ScheduleTask(ctx *Context, name string, data interface{}) error {
+	dataJson, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	// Now insert the credentials into the DB
+	query := `
+		INSERT INTO
+				tasks ("name", "data")
+			  VALUES
+				($1, $2)`
+	tx, err := ctx.MainTx()
+	if err != nil {
+		return err
+	}
+	// Execute query
+	_, err = tx.Exec(query, name, string(dataJson))
+	if err != nil {
+		return err
+	}
+	return nil
+
 }

--- a/cluster/storage-cluster.go
+++ b/cluster/storage-cluster.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	uuid "github.com/satori/go.uuid"
 )
@@ -129,23 +130,46 @@ func AddStorageGroup(ctx *Context, storageClusterID *uuid.UUID, sgName string) c
 	return ch
 }
 
-// GetStorageGroupByName returns a storage group by name
-func GetStorageGroupByName(ctx *Context, name string) (*StorageGroup, error) {
+// GetStorageGroupById returns a storage group by name
+func GetStorageGroupById(ctx *Context, id *uuid.UUID) (*StorageGroup, error) {
+	sg := StorageGroup{}
+	// For now, let's select a storage group at random
 	query := `
-		SELECT 
-				sg.id, sg.name, sg.num
+			SELECT 
+			       sg.id, sg.name, sg.num, sg.storage_cluster_id
 			FROM 
-				storage_groups sg
-			WHERE sg.name=$1 LIMIT 1`
-
-	row := GetInstance().Db.QueryRow(query, name)
-	storageGroup := StorageGroup{}
-	err := row.Scan(&storageGroup.ID, &storageGroup.Name, &storageGroup.Num)
-	if err != nil {
+			     storage_groups sg
+			WHERE sg.id=$1 LIMIT 1;`
+	// non-transactional query as there cannot be a storage group insert along with a read
+	if err := GetInstance().Db.QueryRow(query, id).Scan(&sg.ID, &sg.Name, &sg.Num, &sg.StorageClusterID); err != nil {
+		return nil, err
+	}
+	// get volume counts and host counts
+	queryNodes := `
+			SELECT 
+			       COUNT(*) AS total_nodes 
+			FROM storage_cluster_nodes sgn 
+			WHERE sgn.storage_cluster_id=$1`
+	// non-transactional query as there cannot be a storage group insert along with a read
+	if err := GetInstance().Db.QueryRow(queryNodes, sg.StorageClusterID).Scan(&sg.TotalNodes); err != nil {
 		return nil, err
 	}
 
-	return &storageGroup, nil
+	queryVolumes := `
+			SELECT  ct.total_volumes FROM (SELECT
+				COUNT(*) AS total_volumes, nv.node_id
+			FROM node_volumes nv
+					 LEFT JOIN storage_cluster_nodes scn ON scn.node_id=nv.node_id
+			WHERE scn.storage_cluster_id=$1
+			GROUP BY nv.node_id
+			LIMIT 1) AS ct`
+	// non-transactional query as there cannot be a storage group insert along with a read
+	if err := GetInstance().Db.QueryRow(queryVolumes, sg.StorageClusterID).Scan(&sg.TotalVolumes); err != nil {
+		return nil, err
+	}
+
+	return &sg, nil
+
 }
 
 // provisions the storage group supporting services that point to each node in the storage group
@@ -303,12 +327,12 @@ func GetAllTenantRoutes(ctx *Context) chan []*TenantRoute {
 		defer close(ch)
 		query := `
 			SELECT 
-			       t1.port, t1.service_name, t2.short_name
+			       tsg.port, tsg.service_name, t.short_name, t.domain
 			FROM 
-			tenants_storage_groups t1
-			LEFT JOIN tenants t2
-			ON t1.tenant_id = t2.id
-			WHERE t2.enabled = TRUE
+			tenants_storage_groups tsg
+			LEFT JOIN tenants t
+			ON tsg.tenant_id = t.id
+			WHERE t.enabled = TRUE
 		`
 		// Transactional query tenants may be query as a new one is being inserted
 		tx, err := ctx.MainTx()
@@ -322,18 +346,12 @@ func GetAllTenantRoutes(ctx *Context) chan []*TenantRoute {
 		}
 		var tenants []*TenantRoute
 		for rows.Next() {
-			var tenantShortName string
-			var port int32
-			var serviceName string
-			err = rows.Scan(&port, &serviceName, &tenantShortName)
+			tr := TenantRoute{}
+			err = rows.Scan(&tr.Port, &tr.ServiceName, &tr.ShortName, &tr.Domain)
 			if err != nil {
 				fmt.Println(err)
 			}
-			tenants = append(tenants, &TenantRoute{
-				ShortName:   tenantShortName,
-				Port:        port,
-				ServiceName: serviceName,
-			})
+			tenants = append(tenants, &tr)
 		}
 		ch <- tenants
 	}()
@@ -363,6 +381,7 @@ func (sgt *StorageGroupTenant) HTTPAddress(ssl bool) string {
 
 type TenantRoute struct {
 	ShortName   string
+	Domain      string
 	Port        int32
 	ServiceName string
 }
@@ -453,14 +472,22 @@ func GetTenantStorageGroupByShortName(ctx *Context, tenantShortName string) chan
 		}
 		query := `
 			SELECT 
-			       t1.tenant_id, t1.port, t1.service_name, t2.name, t2.short_name, t2.enabled, t1.storage_group_id, t3.name, t3.num
+			       tsg.tenant_id, 
+			       tsg.port, 
+			       tsg.service_name, 
+			       t.name, 
+			       t.short_name, 
+			       t.enabled, 
+			       tsg.storage_group_id, 
+			       sg.name, 
+			       sg.num
 			FROM 
-			     tenants_storage_groups t1
-			LEFT JOIN tenants t2
-			ON t1.tenant_id = t2.id
-			LEFT JOIN storage_groups t3
-			ON t1.storage_group_id = t3.id
-			WHERE t2.short_name=$1 LIMIT 1`
+			     tenants_storage_groups tsg
+			LEFT JOIN tenants t
+				ON tsg.tenant_id = t.id
+			LEFT JOIN storage_groups sg
+				ON tsg.storage_group_id = sg.id
+			WHERE t.short_name=$1 LIMIT 1`
 		var row *sql.Row
 		// if we received a context, query inside the context
 		if ctx != nil {
@@ -537,7 +564,13 @@ func streamTenantService(maxChanSize int) chan TenantServiceResult {
 		defer close(ch)
 		query :=
 			`SELECT 
-				t.id, t.name, t.short_name, tsg.service_name, tsg.port
+				t.id, 
+       			t.name, 
+			    t.short_name, 
+			    tsg.service_name, 
+			    tsg.port, 
+			    t.enabled, 
+			    t.domain
 			FROM 
 				tenants t LEFT JOIN tenants_storage_groups tsg ON t.id = tsg.tenant_id`
 
@@ -553,7 +586,15 @@ func streamTenantService(maxChanSize int) chan TenantServiceResult {
 			// Save the resulted query on the Tenant and TenantResult result
 			tenant := Tenant{}
 			tRes := TenantServiceResult{}
-			err = rows.Scan(&tenant.ID, &tenant.Name, &tenant.ShortName, &tRes.Service, &tRes.Port)
+			err = rows.Scan(
+				&tenant.ID,
+				&tenant.Name,
+				&tenant.ShortName,
+				&tRes.Service,
+				&tRes.Port,
+				&tenant.Enabled,
+				&tenant.Domain,
+			)
 			if err != nil {
 				ch <- TenantServiceResult{Error: err}
 				return
@@ -570,4 +611,55 @@ func streamTenantService(maxChanSize int) chan TenantServiceResult {
 
 	}()
 	return ch
+}
+
+func SchedulePreProvisionTenantInStorageGroup(ctx *Context, sg *StorageGroup) error {
+	// first check if we can fit 1 more tenant
+	total, err := totalNumberOfTenantInStorageGroup(&sg.ID)
+	if err != nil {
+		return err
+	}
+	if total >= maxNumberOfTenantsPerSg {
+		return errors.New("Max number of tenants on that storage group reached")
+	}
+
+	// pre-provision the first tenant of this storage group
+	provTenantName := strings.ToLower(RandomCharString(16))
+	// check if tenant name is available
+	for {
+		available, err := TenantShortNameAvailable(ctx, provTenantName)
+		if err != nil {
+			log.Println(err)
+			return err
+		}
+		if available {
+			break
+		}
+	}
+	log.Printf("Pre-Provisioning Tenant %s\n", provTenantName)
+	taskData := ProvisionTenantTaskData{
+		TenantShortName: provTenantName,
+		StorageGroupID:  sg.ID,
+	}
+
+	err = ScheduleTask(ctx, TaskProvisionTenant, taskData)
+	if err != nil {
+		log.Printf("WARNING: Could not pre-provision tenant on the storage group `%s`\n", sg.Name)
+	}
+	return nil
+}
+
+func totalNumberOfTenantInStorageGroup(storageGroupID *uuid.UUID) (int32, error) {
+	// get volume counts and host counts
+	queryNodes := `
+			SELECT 
+			       COUNT(*) AS total_tenants 
+			FROM tenants_storage_groups tsg 
+			WHERE tsg.storage_group_id =$1`
+	// non-transactional query as there cannot be a storage group insert along with a read
+	var totalTenants int32
+	if err := GetInstance().Db.QueryRow(queryNodes, storageGroupID).Scan(&totalTenants); err != nil {
+		return totalTenants, err
+	}
+	return totalTenants, nil
 }

--- a/cluster/storage-cluster.go
+++ b/cluster/storage-cluster.go
@@ -130,8 +130,8 @@ func AddStorageGroup(ctx *Context, storageClusterID *uuid.UUID, sgName string) c
 	return ch
 }
 
-// GetStorageGroupById returns a storage group by name
-func GetStorageGroupById(ctx *Context, id *uuid.UUID) (*StorageGroup, error) {
+// GetStorageGroupByID returns a storage group by name
+func GetStorageGroupByID(ctx *Context, id *uuid.UUID) (*StorageGroup, error) {
 	sg := StorageGroup{}
 	// For now, let's select a storage group at random
 	query := `

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -307,7 +307,7 @@ func InviteUserByEmail(ctx *Context, usedFor string, user *User) error {
 
 	// send email with the invite
 
-	tenant, err := GetTenantWithCtx(ctx, ctx.Tenant.ShortName)
+	tenant, err := GetTenantByDomainWithCtx(ctx, ctx.Tenant.ShortName)
 	if err != nil {
 		return fmt.Errorf("tenant: %s", err.Error())
 	}

--- a/cluster/tenants.go
+++ b/cluster/tenants.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -35,6 +36,7 @@ type Tenant struct {
 	ID        uuid.UUID
 	Name      string
 	ShortName string
+	Domain    string
 	Enabled   bool
 }
 
@@ -43,28 +45,19 @@ type AddTenantResult struct {
 	Error error
 }
 
-// TenantAddAction adds a tenant to the cluster, if an admin name and email are provided, the user is created and invited
-// via email.
-func TenantAddAction(ctx *Context, name, shortName, userName, userEmail string) error {
-	// check if tenant name is available
-	available, err := TenantShortNameAvailable(ctx, shortName)
-	if err != nil {
-		log.Println(err)
-		return errors.New("Error tenant's shortname not available")
-	}
-	if !available {
-		return errors.New("Error tenant's shortname not available")
-	}
+type ProvisionTenantTaskData struct {
+	TenantShortName string
+	StorageGroupID  uuid.UUID
+}
 
-	// first find a cluster where to allocate the tenant
-	sg := <-SelectSGWithSpace(ctx)
-	if sg.Error != nil {
-		log.Println("Error no storage group available: ", sg.Error)
-		return errors.New("Error no storage group available")
-	}
+const (
+	TenantDisabled  = false
+	TenantAvailable = true
+)
 
+func ProvisionTenant(ctx *Context, shortName string, sg *StorageGroup) error {
 	// register the tenant
-	tenantResult := <-InsertTenant(ctx, name, shortName)
+	tenantResult := <-InsertTenant(ctx, shortName, shortName)
 	if tenantResult.Error != nil {
 		log.Println("Error adding the tenant to the db: ", tenantResult.Error)
 		return errors.New("Error adding the tenant to the db")
@@ -84,27 +77,64 @@ func TenantAddAction(ctx *Context, name, shortName, userName, userEmail string) 
 		SecretKey: RandomCharString(32)}
 
 	// Create a store for the tenant's configuration
-	err = CreateTenantSecrets(tenantResult.Tenant, &tenantConfig)
-	if err != nil {
+	if err := CreateTenantSecrets(tenantResult.Tenant, &tenantConfig); err != nil {
 		log.Println("Error creating tenant's secrets: ", err)
 		return errors.New("Error creating tenant's secrets")
 	}
 
 	// provision the tenant on that cluster
-	sgTenantResult := <-ProvisionTenantOnStorageGroup(ctx, tenantResult.Tenant, sg.StorageGroup)
+	sgTenantResult := <-ProvisionTenantOnStorageGroup(ctx, tenantResult.Tenant, sg)
 	if sgTenantResult.Error != nil {
 		log.Println("Error provisioning tenant into storage group: ", sgTenantResult.Error)
 		return errors.New("Error provisioning tenant into storage group")
+	}
+	// wait for db provisioning
+	if err := <-tenantSchemaCh; err != nil {
+		log.Println("Error creating tenant's db schema: ", err)
+		return errors.New("Error creating tenant's db schema")
+	}
+
+	// wait for the tenant namespace to finish creating
+	if err := <-namespaceCh; err != nil {
+		log.Println("Error creating tenant's namespace: ", err)
+		return errors.New("Error creating tenant's namespace")
+	}
+	log.Println("Done Provisioning Tenant")
+	return nil
+}
+
+// TenantAddAction adds a tenant to the cluster, if an admin name and email are provided, the user is created and invited
+// via email.
+func TenantAddAction(ctx *Context, name, shortName, userName, userEmail string) error {
+	// check if tenant name is available
+	available, err := TenantShortNameAvailable(ctx, shortName)
+	if err != nil {
+		log.Println(err)
+		return errors.New("Error tenant's shortname not available")
+	}
+	if !available {
+		return errors.New("Error tenant's shortname not available.")
+	}
+
+	// Find an available tenant
+	tenant, err := grabAvailableTenant(ctx)
+	if err != nil {
+		return errors.New("No space available")
+	}
+	// now that we have a tenant, designate it as the tenant to be used in context
+	ctx.Tenant = tenant
+	if err = claimTenant(ctx, tenant, name, shortName); err != nil {
+		return err
+	}
+	sgt := <-GetTenantStorageGroupByShortName(ctx, tenant.ShortName)
+	if sgt.Error != nil {
+		return sgt.Error
 	}
 
 	// announce the tenant on the router
 	nginxCh := UpdateNginxConfiguration(ctx)
 	// check if we were able to provision the schema and be done running the migrations
-	err = <-tenantSchemaCh
-	if err != nil {
-		log.Println("Error creating tenant's db schema: ", err)
-		return errors.New("Error creating tenant's db schema")
-	}
+
 	// wait for router
 	err = <-nginxCh
 	if err != nil {
@@ -112,12 +142,6 @@ func TenantAddAction(ctx *Context, name, shortName, userName, userEmail string) 
 		return errors.New("Error updating nginx configuration")
 	}
 
-	// wait for the tenant namespace to finish creating
-	err = <-namespaceCh
-	if err != nil {
-		log.Println("Error creating tenant's namespace: ", err)
-		return errors.New("Error creating tenant's namespace")
-	}
 	// if the first admin name and email was provided send them an invitation
 	if userName != "" && userEmail != "" {
 		// wait for MinIO to be ready before creating the first user
@@ -133,13 +157,13 @@ func TenantAddAction(ctx *Context, name, shortName, userName, userEmail string) 
 			return errors.New("Error adding first tenant's admin user")
 		}
 		// Get the credentials for a tenant
-		tenantConf, err := GetTenantConfig(tenantResult.Tenant)
+		tenantConf, err := GetTenantConfig(tenant)
 		if err != nil {
 			log.Println("Error getting tenants config", err)
 			return errors.New("Error getting tenants config")
 		}
 		// create minio postgres configuration for bucket notification
-		err = setMinioConfigPostgresNotification(sgTenantResult.StorageGroupTenant, tenantConf)
+		err = setMinioConfigPostgresNotification(sgt.StorageGroupTenant, tenantConf)
 		if err != nil {
 			log.Println("Error setting tenant's minio postgres configuration", err)
 			return errors.New("Error setting tenant's minio postgres configuration")
@@ -151,6 +175,10 @@ func TenantAddAction(ctx *Context, name, shortName, userName, userEmail string) 
 			log.Println("Error inviting user by email: ", err.Error())
 			return errors.New("Error inviting user by email")
 		}
+	}
+	// take one, provision one, tolerate failure of this call
+	if err = SchedulePreProvisionTenantInStorageGroup(ctx, sgt.StorageGroup); err != nil {
+		log.Println("Warning:", err)
 	}
 	return err
 }
@@ -169,15 +197,15 @@ func InsertTenant(ctx *Context, tenantName string, tenantShortName string) chan 
 
 		query :=
 			`INSERT INTO
-				tenants ("id", "name", "short_name", "sys_created_by")
+				tenants ("id", "name", "short_name","enabled", "available", "domain", "sys_created_by")
 			  VALUES
-				($1, $2, $3, $4)`
+				($1, $2, $3, $4, $5, $6, $7)`
 		tx, err := ctx.MainTx()
 		if err != nil {
 			ch <- AddTenantResult{Error: err}
 			return
 		}
-		_, err = tx.Exec(query, tenantID, tenantName, tenantShortName, ctx.WhoAmI)
+		_, err = tx.Exec(query, tenantID, tenantName, tenantShortName, TenantDisabled, TenantAvailable, tenantShortName, ctx.WhoAmI)
 		if err != nil {
 			ch <- AddTenantResult{Error: err}
 			return
@@ -404,15 +432,15 @@ func createTenantNamespace(tenantShortName string) chan error {
 	return ch
 }
 
-// GetTenantWithCtx gets the Tenant if it exists on the m3.provisining.tenants table
+// GetTenantByDomainWithCtx gets the Tenant if it exists on the m3.provisining.tenants table
 // search is done by tenant name
-func GetTenantWithCtx(ctx *Context, tenantName string) (tenant Tenant, err error) {
+func GetTenantByDomainWithCtx(ctx *Context, tenantDomain string) (tenant Tenant, err error) {
 	query :=
 		`SELECT 
-				t1.id, t1.name, t1.short_name, t1.enabled
+				t1.id, t1.name, t1.short_name, t1.enabled, t1.domain
 			FROM 
 				tenants t1
-			WHERE short_name=$1`
+			WHERE domain=$1`
 	// non-transactional query
 	var row *sql.Row
 	// did we got a context? query inside of it
@@ -424,11 +452,11 @@ func GetTenantWithCtx(ctx *Context, tenantName string) (tenant Tenant, err error
 		row = tx.QueryRow(query, ctx.Tenant.ShortName)
 	} else {
 		// no context? straight to db
-		row = GetInstance().Db.QueryRow(query, tenantName)
+		row = GetInstance().Db.QueryRow(query, tenantDomain)
 	}
 
 	// Save the resulted query on the User struct
-	err = row.Scan(&tenant.ID, &tenant.Name, &tenant.ShortName, &tenant.Enabled)
+	err = row.Scan(&tenant.ID, &tenant.Name, &tenant.ShortName, &tenant.Enabled, &tenant.Domain)
 	if err != nil {
 		return tenant, err
 	}
@@ -445,7 +473,7 @@ func GetTenantByID(tenantID *uuid.UUID) (tenant Tenant, err error) {
 func GetTenantWithCtxByID(ctx *Context, tenantID *uuid.UUID) (tenant Tenant, err error) {
 	query :=
 		`SELECT 
-				t1.id, t1.name, t1.short_name, t1.enabled
+				t1.id, t1.name, t1.short_name, t1.enabled, t1.domain
 			FROM 
 				tenants t1
 			WHERE t1.id=$1`
@@ -464,15 +492,15 @@ func GetTenantWithCtxByID(ctx *Context, tenantID *uuid.UUID) (tenant Tenant, err
 	}
 
 	// Save the resulted query on the User struct
-	err = row.Scan(&tenant.ID, &tenant.Name, &tenant.ShortName, &tenant.Enabled)
+	err = row.Scan(&tenant.ID, &tenant.Name, &tenant.ShortName, &tenant.Enabled, &tenant.Domain)
 	if err != nil {
 		return tenant, err
 	}
 	return tenant, nil
 }
 
-func GetTenant(tenantName string) (tenant Tenant, err error) {
-	return GetTenantWithCtx(nil, tenantName)
+func GetTenantByDomain(tenantDomain string) (tenant Tenant, err error) {
+	return GetTenantByDomainWithCtx(nil, tenantDomain)
 }
 
 // DeleteTenant runs all the logic to remove a tenant from the cluster.
@@ -727,7 +755,7 @@ func createTenantConfigMap(sgTenant *StorageGroupTenant) error {
 func GetTenantWithCtxByServiceName(ctx *Context, serviceName string) (tenant Tenant, err error) {
 	query :=
 		`SELECT 
-				t1.id, t1.name, t1.short_name, t1.enabled
+				t1.id, t1.name, t1.short_name, t1.enabled, t1.domain
 			FROM 
 				tenants t1 LEFT JOIN tenants_storage_groups tsg ON t1.id = tsg.tenant_id
 			WHERE tsg.service_name=$1`
@@ -746,9 +774,83 @@ func GetTenantWithCtxByServiceName(ctx *Context, serviceName string) (tenant Ten
 	}
 
 	// Save the resulted query on the User struct
-	err = row.Scan(&tenant.ID, &tenant.Name, &tenant.ShortName, &tenant.Enabled)
+	err = row.Scan(&tenant.ID, &tenant.Name, &tenant.ShortName, &tenant.Enabled, &tenant.Domain)
 	if err != nil {
 		return tenant, err
 	}
 	return tenant, nil
+}
+
+// ProvisionTenantTask takes a task for provisioning of a tenant and executes it
+func ProvisionTenantTask(task *Task) error {
+	ctx, err := NewEmptyContext()
+	if err != nil {
+		return err
+	}
+	// hydrate the data from the task
+	var taskData ProvisionTenantTaskData
+	err = json.Unmarshal(task.Data, &taskData)
+	if err != nil {
+		return err
+	}
+	// get the storage group where the tenant will be placed
+	sg, err := GetStorageGroupById(ctx, &taskData.StorageGroupID)
+	if err != nil {
+		return err
+	}
+	// Provision the tenant
+	err = ProvisionTenant(ctx, taskData.TenantShortName, sg)
+	if err != nil {
+		return err
+	}
+	// if all good, commit to DB
+	if err := ctx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// grabAvailableTenant will select an available tenant and mark it for update so it cannot be grabbed by a different
+// process.
+func grabAvailableTenant(ctx *Context) (*Tenant, error) {
+	query :=
+		`SELECT 
+				t1.id, t1.name, t1.short_name, t1.enabled, t1.domain
+			FROM 
+				tenants t1
+			WHERE t1.available=TRUE
+			LIMIT 1
+			FOR UPDATE`
+	// transactional query
+	tx, err := ctx.MainTx()
+	if err != nil {
+		return nil, err
+	}
+	row := tx.QueryRow(query)
+	// Save the resulted query on the User struct
+	tenant := Tenant{}
+	if err = row.Scan(&tenant.ID, &tenant.Name, &tenant.ShortName, &tenant.Enabled, &tenant.Domain); err != nil {
+		return nil, err
+	}
+	return &tenant, nil
+}
+
+// claimTenant claims a tenant to a new account, marks it as not available and enables it for the router
+func claimTenant(ctx *Context, tenant *Tenant, name, domain string) error {
+	// build the query
+	query :=
+		`UPDATE tenants 
+					SET name = $1, domain = $2, available=FALSE, enabled=TRUE
+				WHERE id=$3`
+
+	// Execute Query
+	tx, err := ctx.MainTx()
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(query, name, domain, tenant.ID)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/cluster/tenants.go
+++ b/cluster/tenants.go
@@ -105,15 +105,15 @@ func ProvisionTenant(ctx *Context, shortName string, sg *StorageGroup) error {
 
 // TenantAddAction adds a tenant to the cluster, if an admin name and email are provided, the user is created and invited
 // via email.
-func TenantAddAction(ctx *Context, name, shortName, userName, userEmail string) error {
+func TenantAddAction(ctx *Context, name, domain, userName, userEmail string) error {
 	// check if tenant name is available
-	available, err := TenantShortNameAvailable(ctx, shortName)
+	available, err := TenantShortNameAvailable(ctx, domain)
 	if err != nil {
 		log.Println(err)
-		return errors.New("Error tenant's shortname not available")
+		return errors.New("Error validating domain")
 	}
 	if !available {
-		return errors.New("Error tenant's shortname not available.")
+		return errors.New("Error tenant's shortname not available")
 	}
 
 	// Find an available tenant
@@ -123,7 +123,7 @@ func TenantAddAction(ctx *Context, name, shortName, userName, userEmail string) 
 	}
 	// now that we have a tenant, designate it as the tenant to be used in context
 	ctx.Tenant = tenant
-	if err = claimTenant(ctx, tenant, name, shortName); err != nil {
+	if err = claimTenant(ctx, tenant, name, domain); err != nil {
 		return err
 	}
 	sgt := <-GetTenantStorageGroupByShortName(ctx, tenant.ShortName)
@@ -794,7 +794,7 @@ func ProvisionTenantTask(task *Task) error {
 		return err
 	}
 	// get the storage group where the tenant will be placed
-	sg, err := GetStorageGroupById(ctx, &taskData.StorageGroupID)
+	sg, err := GetStorageGroupByID(ctx, &taskData.StorageGroupID)
 	if err != nil {
 		return err
 	}

--- a/cmd/m3/tenant-service-account-add.go
+++ b/cmd/m3/tenant-service-account-add.go
@@ -79,7 +79,7 @@ func tenantServiceAccountAdd(ctx *cli.Context) error {
 		desc = &description
 	}
 	//validate tenant
-	tenant, err := cluster.GetTenant(tenantShortName)
+	tenant, err := cluster.GetTenantByDomain(tenantShortName)
 	if err != nil {
 		return err
 	}

--- a/cmd/m3/tenant-service-account-list.go
+++ b/cmd/m3/tenant-service-account-list.go
@@ -84,7 +84,7 @@ func tenantServiceAccountList(ctx *cli.Context) error {
 		return errMissingArguments
 	}
 	//validate tenant
-	tenant, err := cluster.GetTenant(tenantShortName)
+	tenant, err := cluster.GetTenantByDomain(tenantShortName)
 	if err != nil {
 		fmt.Println("Invalid tenant")
 		return err

--- a/cmd/m3/tenant-user-list.go
+++ b/cmd/m3/tenant-user-list.go
@@ -84,7 +84,7 @@ func tenantUserList(ctx *cli.Context) error {
 		return errMissingArguments
 	}
 	//validate tenant
-	tenant, err := cluster.GetTenant(tenantShortName)
+	tenant, err := cluster.GetTenantByDomain(tenantShortName)
 	if err != nil {
 		return err
 	}

--- a/k8s/setup-tenant.sh
+++ b/k8s/setup-tenant.sh
@@ -13,4 +13,4 @@
 
 ./m3 cluster sc sg add --storage_cluster my-dc-rack-1 --name group-1
 
-./m3 tenant add "Acme Inc." --short_name acme --admin_name="Your Name" --admin_email="your@mail.com"
+#./m3 tenant add "Acme Inc." --short_name acme --admin_name="Your Name" --admin_email="your@mail.com"


### PR DESCRIPTION
Big change.

This introduces tenant pre-provisioning, which allocated a tenant with a randomized `short name` and gets created via `Task Scheduler` so it sits waiting for a `tenant add` action, to grab it, when it becomes taken, a new tenant is pre-provisioned, up to 16 per storage group.

Adding multiple storage groups will guarantee multiple tenants can be added quickly.

The old "short name"  identifier for a tenant was moved to the `domain` field