### PR TITLE
Move all DB queries to Transactions withing Context

### DIFF
--- a/api/api-private-authentication.go
+++ b/api/api-private-authentication.go
@@ -35,7 +35,7 @@ import (
 // Login rpc to generate a session for an admin
 func (ps *privateServer) Login(ctx context.Context, in *pb.CLILoginRequest) (*pb.CLILoginResponse, error) {
 	// start app context
-	appCtx, err := cluster.NewEmptyContext()
+	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
 
 	// Password validation
 	// Look for the user on the database by email
@@ -76,7 +76,7 @@ func (ps *privateServer) Login(ctx context.Context, in *pb.CLILoginRequest) (*pb
 // Login rpc to validate account against a configured idp and generate an admin session
 func (ps *privateServer) LoginWithIdp(ctx context.Context, in *pb.LoginWithIdpRequest) (*pb.CLILoginResponse, error) {
 	// start app context
-	appCtx, err := cluster.NewEmptyContext()
+	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
 	// Add the session within a transaction in case anything goes wrong during the adding process
 	defer func() {
 		if err != nil {

--- a/api/api-private-cluster.go
+++ b/api/api-private-cluster.go
@@ -29,7 +29,7 @@ import (
 
 // ClusterStorageClusterAdd rpc to add a new storage cluster
 func (ps *privateServer) ClusterStorageClusterAdd(ctx context.Context, in *pb.StorageClusterAddRequest) (*pb.StorageClusterAddResponse, error) {
-	appCtx, err := cluster.NewEmptyContext()
+	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
 	if err != nil {
 		return nil, status.New(codes.Internal, "An internal error happened").Err()
 	}
@@ -83,7 +83,7 @@ func (ps *privateServer) ClusterStorageGroupAdd(ctx context.Context, in *pb.Stor
 	if !re.MatchString(in.Name) {
 		return nil, status.New(codes.InvalidArgument, "Invalid storage group name.").Err()
 	}
-	appCtx, err := cluster.NewEmptyContext()
+	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
 	if err != nil {
 		return nil, status.New(codes.Internal, "An internal error happened").Err()
 	}

--- a/api/api-private-setup.go
+++ b/api/api-private-setup.go
@@ -29,7 +29,12 @@ import (
 
 // SetupDB installs the base schema
 func (ps *privateServer) SetupDB(ctx context.Context, in *pb.AdminEmpty) (*pb.AdminEmpty, error) {
-	err := cluster.SetupDBAction()
+	appCtx, err := cluster.NewEmptyContext()
+	if err != nil {
+		return nil, status.New(codes.Internal, err.Error()).Err()
+	}
+
+	err = cluster.SetupDBAction(appCtx)
 	if err != nil {
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}

--- a/api/api-private-setup.go
+++ b/api/api-private-setup.go
@@ -29,12 +29,7 @@ import (
 
 // SetupDB installs the base schema
 func (ps *privateServer) SetupDB(ctx context.Context, in *pb.AdminEmpty) (*pb.AdminEmpty, error) {
-	appCtx, err := cluster.NewEmptyContext()
-	if err != nil {
-		return nil, status.New(codes.Internal, err.Error()).Err()
-	}
-
-	err = cluster.SetupDBAction(appCtx)
+	err := cluster.SetupDBAction()
 	if err != nil {
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}

--- a/api/api-private-tenant-bucket.go
+++ b/api/api-private-tenant-bucket.go
@@ -50,7 +50,9 @@ func (ps *privateServer) TenantBucketAdd(ctx context.Context, in *pb.TenantBucke
 		log.Println(err)
 		return nil, err
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal Error").Err()
+	}
 
 	err = cluster.MakeBucket(appCtx, tenant.ShortName, in.BucketName, cluster.BucketPrivate)
 	if err != nil {

--- a/api/api-private-tenant-bucket.go
+++ b/api/api-private-tenant-bucket.go
@@ -45,7 +45,11 @@ func (ps *privateServer) TenantBucketAdd(ctx context.Context, in *pb.TenantBucke
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 
+<<<<<<< HEAD
 	err = cluster.MakeBucket(appCtx, tenant.ShortName, in.BucketName, cluster.BucketPrivate)
+=======
+	err = cluster.MakeBucket(appCtx, in.BucketName, cluster.BucketPrivate)
+>>>>>>> fixes to errors withing a txn
 	if err != nil {
 		fmt.Println("Error creating bucket:", err.Error())
 		return nil, status.New(codes.Internal, "Failed to make bucket").Err()

--- a/api/api-private-tenant-permissions.go
+++ b/api/api-private-tenant-permissions.go
@@ -54,7 +54,9 @@ func (ps *privateServer) TenantPermissionAdd(ctx context.Context, in *pb.TenantP
 	if err != nil {
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 
 	if _, err := cluster.AddPermissionToDB(appCtx, in.Name, in.Description, effect, in.Resources, in.Actions); err != nil {
 		appCtx.Rollback()
@@ -79,7 +81,9 @@ func (ps *privateServer) TenantPermissionList(ctx context.Context, in *pb.Tenant
 		log.Println(err)
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 	// perform actions
 	perms, err := cluster.ListPermissions(appCtx, in.Offset, in.Limit)
 	if err != nil {
@@ -133,7 +137,9 @@ func (ps *privateServer) TenantPermissionAssign(ctx context.Context, in *pb.Tena
 		log.Println(err)
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 
 	// validate the permission
 	// get the permission to see if it's valid

--- a/api/api-private-tenant-permissions.go
+++ b/api/api-private-tenant-permissions.go
@@ -66,13 +66,13 @@ func (ps *privateServer) TenantPermissionList(ctx context.Context, in *pb.Tenant
 	appCtx, err := getContextIfValidTenant(ctx, in.Tenant)
 	if err != nil {
 		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal error 1").Err()
+		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 	// perform actions
 	perms, err := cluster.ListPermissions(appCtx, in.Offset, in.Limit)
 	if err != nil {
 		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal error 2").Err()
+		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 	//transform the permissions to pb format
 	var pbPerms []*pb.Permission

--- a/api/api-private-tenant-permissions.go
+++ b/api/api-private-tenant-permissions.go
@@ -66,13 +66,13 @@ func (ps *privateServer) TenantPermissionList(ctx context.Context, in *pb.Tenant
 	appCtx, err := getContextIfValidTenant(ctx, in.Tenant)
 	if err != nil {
 		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal error").Err()
+		return nil, status.New(codes.Internal, "Internal error 1").Err()
 	}
 	// perform actions
 	perms, err := cluster.ListPermissions(appCtx, in.Offset, in.Limit)
 	if err != nil {
 		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal error").Err()
+		return nil, status.New(codes.Internal, "Internal error 2").Err()
 	}
 	//transform the permissions to pb format
 	var pbPerms []*pb.Permission

--- a/api/api-private-tenant-permissions.go
+++ b/api/api-private-tenant-permissions.go
@@ -45,16 +45,9 @@ func (ps *privateServer) TenantPermissionAdd(ctx context.Context, in *pb.TenantP
 		return nil, err
 	}
 
-	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
+	appCtx, err := getContextIfValidTenant(ctx, in.Tenant)
 	if err != nil {
-		return nil, status.New(codes.Internal, "Internal error").Err()
-	}
-	// validate Tenant
-	tenant, err := cluster.GetTenantByDomain(in.Tenant)
-	if err != nil {
-		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
-	}
-	if err := appCtx.SetTenant(&tenant); err != nil {
+		log.Println(err)
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 
@@ -70,18 +63,9 @@ func (ps *privateServer) TenantPermissionAdd(ctx context.Context, in *pb.TenantP
 }
 
 func (ps *privateServer) TenantPermissionList(ctx context.Context, in *pb.TenantPermissionListRequest) (*pb.TenantPermissionListResponse, error) {
-	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
+	appCtx, err := getContextIfValidTenant(ctx, in.Tenant)
 	if err != nil {
 		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal error").Err()
-	}
-	// validate Tenant
-	tenant, err := cluster.GetTenantByDomain(in.Tenant)
-	if err != nil {
-		log.Println(err)
-		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
-	}
-	if err := appCtx.SetTenant(&tenant); err != nil {
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 	// perform actions
@@ -125,19 +109,9 @@ func (ps *privateServer) TenantPermissionList(ctx context.Context, in *pb.Tenant
 // TenantPermissionAssign provides the endpoint to assign a permission by id-name to multiple service accounts by
 // id-name as well.
 func (ps *privateServer) TenantPermissionAssign(ctx context.Context, in *pb.TenantPermissionAssignRequest) (*pb.TenantPermissionAssignResponse, error) {
-	// get context
-	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
+	appCtx, err := getContextIfValidTenant(ctx, in.Tenant)
 	if err != nil {
 		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal error").Err()
-	}
-	// validate Tenant
-	tenant, err := cluster.GetTenantByDomain(in.Tenant)
-	if err != nil {
-		log.Println(err)
-		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
-	}
-	if err := appCtx.SetTenant(&tenant); err != nil {
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 

--- a/api/api-private-tenant-service-account.go
+++ b/api/api-private-tenant-service-account.go
@@ -52,7 +52,7 @@ func (ps *privateServer) TenantServiceAccountUpdatePolicy(ctx context.Context, i
 	saID := saToStrmap[in.ServiceAccount]
 
 	// Get in which SG is the tenant located
-	sgt := <-cluster.GetTenantStorageGroupByShortName(appCtx, appCtx.Tenant.ShortName)
+	sgt := <-cluster.GetTenantStorageGroupByShortName(appCtx, appCtx.Tenant().ShortName)
 
 	if sgt.Error != nil {
 		log.Println(sgt.Error)
@@ -60,7 +60,7 @@ func (ps *privateServer) TenantServiceAccountUpdatePolicy(ctx context.Context, i
 	}
 
 	// Get the credentials for a tenant
-	tenantConf, err := cluster.GetTenantConfig(appCtx.Tenant)
+	tenantConf, err := cluster.GetTenantConfig(appCtx.Tenant())
 	if err != nil {
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
@@ -94,7 +94,9 @@ func (ps *privateServer) TenantServiceAccountAssign(ctx context.Context, in *pb.
 		log.Println(err)
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 
 	// validate the permission
 	// get the permission to see if it's valid

--- a/api/api-private-tenant-service-account.go
+++ b/api/api-private-tenant-service-account.go
@@ -82,19 +82,9 @@ func (ps *privateServer) TenantServiceAccountUpdatePolicy(ctx context.Context, i
 // TenantPermissionAssign provides the endpoint to assign a permission by id-name to multiple service accounts by
 // id-name as well.
 func (ps *privateServer) TenantServiceAccountAssign(ctx context.Context, in *pb.TenantServiceAccountAssignRequest) (*pb.TenantServiceAccountAssignResponse, error) {
-	// get context
-	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
+	appCtx, err := getContextIfValidTenant(ctx, in.Tenant)
 	if err != nil {
 		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal error").Err()
-	}
-	// validate Tenant
-	tenant, err := cluster.GetTenantByDomain(in.Tenant)
-	if err != nil {
-		log.Println(err)
-		return nil, status.New(codes.InvalidArgument, "Invalid tenant name").Err()
-	}
-	if err := appCtx.SetTenant(&tenant); err != nil {
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 

--- a/api/api-private-tenant-user.go
+++ b/api/api-private-tenant-user.go
@@ -58,7 +58,9 @@ func (ps *privateServer) TenantUserAdd(ctx context.Context, in *pb.TenantUserAdd
 		log.Println(err)
 		return nil, status.New(codes.NotFound, "Tenant not found").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 	// perform the action
 	err = cluster.AddUser(appCtx, &user)
 	if err != nil {
@@ -115,7 +117,9 @@ func (ps *privateServer) TenantUserDelete(ctx context.Context, in *pb.TenantUser
 		log.Println(err)
 		return nil, status.New(codes.NotFound, "Tenant not found").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 	user, err := cluster.GetUserByEmail(appCtx, in.Email)
 	if err != nil {
 		log.Println(err)
@@ -145,7 +149,10 @@ func (ps *privateServer) TenantUserForgotPassword(ctx context.Context, in *pb.Te
 		return nil, status.New(codes.InvalidArgument, "Invalid tenant").Err()
 	}
 	// start context
-	appCtx := cluster.NewCtxWithTenant(&tenant)
+	appCtx, err := cluster.NewCtxWithTenant(&tenant)
+	if err != nil {
+		return nil, err
+	}
 
 	user, err := cluster.GetUserByEmail(appCtx, in.Email)
 	if err != nil {

--- a/api/api-private-tenant-user.go
+++ b/api/api-private-tenant-user.go
@@ -139,7 +139,7 @@ func (ps *privateServer) TenantUserForgotPassword(ctx context.Context, in *pb.Te
 	}
 
 	// Send email invitation with token
-	err = cluster.InviteUserByEmail(appCtx, cluster.TokenResetPasswordEmail, &user)
+	err = cluster.InviteUserByEmail(appCtx, cluster.TokenResetPasswordEmail, user)
 	if err != nil {
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}

--- a/api/api-private-tenant.go
+++ b/api/api-private-tenant.go
@@ -193,10 +193,12 @@ func (ps *privateServer) TenantDisable(ctx context.Context, in *pb.TenantSingleR
 		log.Println(err)
 		return nil, status.New(codes.NotFound, "Tenant not found").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 
 	// Update Tenant's enabled status on DB
-	err = cluster.UpdateTenantEnabledStatus(appCtx, &appCtx.Tenant.ID, false)
+	err = cluster.UpdateTenantEnabledStatus(appCtx, &appCtx.Tenant().ID, false)
 	if err != nil {
 		log.Println("error setting tenant's enabled column:", err)
 		return nil, status.New(codes.Internal, "error setting tenant's enabled status").Err()
@@ -238,10 +240,12 @@ func (ps *privateServer) TenantEnable(ctx context.Context, in *pb.TenantSingleRe
 		log.Println(err)
 		return nil, status.New(codes.NotFound, "Tenant not found").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 
 	// Update Tenant's enabled status on DB
-	err = cluster.UpdateTenantEnabledStatus(appCtx, &appCtx.Tenant.ID, true)
+	err = cluster.UpdateTenantEnabledStatus(appCtx, &appCtx.Tenant().ID, true)
 	if err != nil {
 		log.Println("error setting tenant's enabled column:", err)
 		return nil, status.New(codes.Internal, "error setting tenant's enabled status").Err()
@@ -376,9 +380,11 @@ func (ps *privateServer) TenantCostSet(ctx context.Context, in *pb.TenantCostReq
 		log.Println(err)
 		return nil, status.New(codes.NotFound, "Tenant not found").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 
-	err = cluster.UpdateTenantCost(appCtx, &appCtx.Tenant.ID, tenantCostMultiplier)
+	err = cluster.UpdateTenantCost(appCtx, &appCtx.Tenant().ID, tenantCostMultiplier)
 	if err != nil {
 		log.Println("error setting tenant's cost multiplier:", err)
 		return nil, status.New(codes.Internal, "error setting tenant's cost multiplier").Err()

--- a/api/api-private-tenant.go
+++ b/api/api-private-tenant.go
@@ -42,7 +42,6 @@ func (ps *privateServer) TenantAdd(in *pb.TenantAddRequest, stream pb.PrivateAPI
 			appCtx.Rollback()
 			return
 		}
-		log.Println("COMMITING ADD TENANT")
 		err = appCtx.Commit()
 	}()
 	if err = stream.Send(progressStruct(10, "validating tenant")); err != nil {

--- a/api/api-private-tenant.go
+++ b/api/api-private-tenant.go
@@ -191,15 +191,15 @@ func (ps *privateServer) TenantDisable(ctx context.Context, in *pb.TenantSingleR
 		log.Println("error setting tenant's enabled column:", err)
 		return nil, status.New(codes.Internal, "error setting tenant's enabled status").Err()
 	}
-	// if we reach here, all is good, commit
-	if err := appCtx.Commit(); err != nil {
-		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal error").Err()
-	}
 	// Update nginx configurations without the disabled tenants.
 	err = <-cluster.UpdateNginxConfiguration(appCtx)
 	if err != nil {
 		fmt.Println(err)
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
+	// if we reach here, all is good, commit
+	if err := appCtx.Commit(); err != nil {
+		log.Println(err)
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 	return &pb.Empty{}, nil
@@ -230,15 +230,15 @@ func (ps *privateServer) TenantEnable(ctx context.Context, in *pb.TenantSingleRe
 		log.Println("error setting tenant's enabled column:", err)
 		return nil, status.New(codes.Internal, "error setting tenant's enabled status").Err()
 	}
-	// if we reach here, all is good, commit
-	if err := appCtx.Commit(); err != nil {
-		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal error").Err()
-	}
 	// Update nginx configurations without the disabled tenants.
 	err = <-cluster.UpdateNginxConfiguration(appCtx)
 	if err != nil {
 		fmt.Println(err)
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
+	// if we reach here, all is good, commit
+	if err := appCtx.Commit(); err != nil {
+		log.Println(err)
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 	return &pb.Empty{}, nil

--- a/api/api-public-authentication-grpc.go
+++ b/api/api-public-authentication-grpc.go
@@ -183,7 +183,7 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (*pb.LoginRespo
 	}
 
 	// Everything looks good, create session
-	session, err := cluster.CreateSession(appCtx, &user, tenant)
+	session, err := cluster.CreateSession(appCtx, user, tenant)
 	//if err != nil {
 	//	return nil, status.New(codes.Internal, err.Error()).Err()
 	//}

--- a/api/api-public-authentication-grpc.go
+++ b/api/api-public-authentication-grpc.go
@@ -54,7 +54,9 @@ func (s *server) SetPassword(ctx context.Context, in *pb.SetPasswordRequest) (*p
 		log.Println(err)
 		return nil, status.New(codes.Unauthenticated, "invalid URL Token").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 
 	urlToken, err := cluster.GetTenantTokenDetails(appCtx, &parsedJwtToken.Token)
 	if err != nil {
@@ -100,7 +102,10 @@ func (s *server) ValidateInvite(ctx context.Context, in *pb.ValidateInviteReques
 		log.Println("error getting tenant by id:", err)
 		return nil, status.New(codes.Unauthenticated, "invalid token").Err()
 	}
-	appCtx := cluster.NewCtxWithTenant(&tenant)
+	appCtx, err := cluster.NewCtxWithTenant(&tenant)
+	if err != nil {
+		return nil, err
+	}
 
 	urlToken, err := cluster.GetTenantTokenDetails(appCtx, &parsedJwtToken.Token)
 	if err != nil {
@@ -147,7 +152,9 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (res *pb.LoginR
 		log.Println(err)
 		return nil, status.New(codes.Internal, "internal Error").Err()
 	}
-	appCtx.Tenant = &tenant
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
 
 	// Password validation
 	// Look for the user on the database by email

--- a/api/api-public-authentication-grpc.go
+++ b/api/api-public-authentication-grpc.go
@@ -44,7 +44,7 @@ func (s *server) SetPassword(ctx context.Context, in *pb.SetPasswordRequest) (*p
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}
 
-	appCtx, err := cluster.NewEmptyContext()
+	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
 	if err != nil {
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}

--- a/api/api-public-authentication-grpc.go
+++ b/api/api-public-authentication-grpc.go
@@ -98,12 +98,7 @@ func (s *server) ValidateInvite(ctx context.Context, in *pb.ValidateInviteReques
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}
 
-	tenant, err := cluster.GetTenantByID(&parsedJwtToken.TenantID)
-	if err != nil {
-		log.Println("error getting tenant by id:", err)
-		return nil, status.New(codes.Unauthenticated, "invalid token").Err()
-	}
-	appCtx, err := cluster.NewCtxWithTenant(&tenant)
+	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +160,7 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (*pb.LoginRespo
 		return nil, status.New(codes.Unauthenticated, "user account disabled, contact support").Err()
 	}
 
-	if err := appCtx.SetTenant(&tenant); err != nil {
+	if err := appCtx.SetTenant(tenant); err != nil {
 		return nil, status.New(codes.Internal, "Internal error").Err()
 	}
 
@@ -188,7 +183,7 @@ func (s *server) Login(ctx context.Context, in *pb.LoginRequest) (*pb.LoginRespo
 	}
 
 	// Everything looks good, create session
-	session, err := cluster.CreateSession(appCtx, &user, &tenant)
+	session, err := cluster.CreateSession(appCtx, &user, tenant)
 	//if err != nil {
 	//	return nil, status.New(codes.Internal, err.Error()).Err()
 	//}

--- a/api/api-public-authentication-grpc.go
+++ b/api/api-public-authentication-grpc.go
@@ -73,13 +73,14 @@ func (s *server) SetPassword(ctx context.Context, in *pb.SetPasswordRequest) (*p
 	err = cluster.CompleteSignup(appCtx, urlToken, reqPassword)
 	if err != nil {
 		log.Println(err)
-		appCtx.Rollback()
+		if err = appCtx.Rollback(); err != nil {
+			log.Println(err)
+		}
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}
 
 	// no errors? lets commit
-	err = appCtx.Commit()
-	if err != nil {
+	if err = appCtx.Commit(); err != nil {
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}
 	return &pb.Empty{}, nil

--- a/api/api-public-bucket-grpc.go
+++ b/api/api-public-bucket-grpc.go
@@ -97,6 +97,12 @@ func (s *server) ListBuckets(ctx context.Context, in *pb.ListBucketsRequest) (*p
 	bucketsSizes, err := cluster.GetLatestBucketsSizes(appCtx)
 	if err != nil {
 		log.Println("error getting buckets sizes:", err)
+		if err == cluster.ErrNoBucketSizes {
+			// introduce empty bucket size
+			bucketsSizes = make(map[string]uint64)
+		} else {
+			return nil, status.New(codes.Internal, "Failed to list buckets").Err()
+		}
 	}
 
 	var buckets []*pb.Bucket

--- a/api/api-public-bucket-grpc.go
+++ b/api/api-public-bucket-grpc.go
@@ -91,7 +91,7 @@ func (s *server) ListBuckets(ctx context.Context, in *pb.ListBucketsRequest) (*p
 	// TODO: Update List bucket to use context so the tenant is read automatically
 	// List buckets in the tenant's MinIO
 	var bucketInfos []cluster.TenantBucketInfo
-	bucketInfos, err = cluster.ListBuckets(appCtx.Tenant.ShortName)
+	bucketInfos, err = cluster.ListBuckets(appCtx.Tenant().ShortName)
 	if err != nil {
 		log.Println(err)
 		return nil, status.New(codes.Internal, "Failed to list buckets").Err()

--- a/api/api-public-bucket-grpc.go
+++ b/api/api-public-bucket-grpc.go
@@ -41,10 +41,7 @@ func (s *server) MakeBucket(ctx context.Context, in *pb.MakeBucketRequest) (*pb.
 		return nil, status.New(codes.Internal, "Internal Error").Err()
 	}
 
-	// get tenant short name from context
-	tenantShortName := ctx.Value(cluster.TenantShortNameKey).(string)
-	// TODO: Update to use context
-	err = cluster.MakeBucket(appCtx, tenantShortName, bucket, accessType)
+	err = cluster.MakeBucket(appCtx, bucket, accessType)
 	if err != nil {
 		return nil, status.New(codes.Internal, "Failed to make bucket").Err()
 	}

--- a/api/api-public-metrics.go
+++ b/api/api-public-metrics.go
@@ -44,6 +44,7 @@ func (s *server) Metrics(ctx context.Context, in *pb.MetricsRequest) (res *pb.Me
 		log.Println(err)
 		return nil, status.New(codes.Internal, "internal error").Err()
 	}
+	defer appCtx.Rollback()
 	totalBucketsCount, err := cluster.GetLatestTotalBuckets(appCtx, dateFormatted)
 	if err != nil {
 		log.Println("error getting latest total number of buckets:", err)

--- a/api/api-public-tenant-permissions.go
+++ b/api/api-public-tenant-permissions.go
@@ -165,10 +165,6 @@ func (s *server) UpdatePermission(ctx context.Context, in *pb.UpdatePermissionRe
 	if err != nil {
 		return nil, status.New(codes.Internal, "error updating permission").Err()
 	}
-	// if we reach here, all is good, commit
-	if err := appCtx.Commit(); err != nil {
-		return nil, err
-	}
 
 	// UPDATE All Service Accounts using the updated  permission
 	serviceAccountIDs, err := cluster.GetAllServiceAccountsForPermission(appCtx, &permission.ID)
@@ -187,6 +183,11 @@ func (s *server) UpdatePermission(ctx context.Context, in *pb.UpdatePermissionRe
 	}
 	// Create response object
 	permissionResponse := buildPermissionPBFromPermission(updatedPermission)
+
+	// if we reach here, all is good, commit
+	if err := appCtx.Commit(); err != nil {
+		return nil, err
+	}
 
 	return permissionResponse, nil
 }
@@ -320,11 +321,6 @@ func (s *server) RemovePermission(ctx context.Context, in *pb.PermissionActionRe
 		return nil, status.New(codes.Internal, "failed deleting permission").Err()
 	}
 
-	// if we reach here, all is good, commit
-	if err := appCtx.Commit(); err != nil {
-		return nil, err
-	}
-
 	// UPDATE All Service Accounts that were using the deleted permission
 	serviceAccountIDs, err := cluster.GetAllServiceAccountsForPermission(appCtx, &permission.ID)
 	if err != nil {
@@ -333,6 +329,11 @@ func (s *server) RemovePermission(ctx context.Context, in *pb.PermissionActionRe
 	err = cluster.UpdatePoliciesForMultipleServiceAccount(appCtx, serviceAccountIDs)
 	if err != nil {
 		return nil, status.New(codes.Internal, "error updating service accounts").Err()
+	}
+
+	// if we reach here, all is good, commit
+	if err := appCtx.Commit(); err != nil {
+		return nil, err
 	}
 
 	return &pb.Empty{}, nil

--- a/api/api-public-tenant-service-account.go
+++ b/api/api-public-tenant-service-account.go
@@ -53,7 +53,7 @@ func (s *server) CreateServiceAccount(ctx context.Context, in *pb.CreateServiceA
 		err = appCtx.Commit()
 	}()
 
-	serviceAccount, saCred, err := cluster.AddServiceAccount(appCtx, appCtx.Tenant.ShortName, name, &name)
+	serviceAccount, saCred, err := cluster.AddServiceAccount(appCtx, appCtx.Tenant().ShortName, name, &name)
 	if err != nil {
 		log.Println(err.Error())
 		return nil, status.New(codes.Internal, "error creating service account").Err()

--- a/api/api-public-tenant-service-account.go
+++ b/api/api-public-tenant-service-account.go
@@ -182,10 +182,6 @@ func (s *server) UpdateServiceAccount(ctx context.Context, in *pb.UpdateServiceA
 		log.Println(err.Error())
 		return nil, status.New(codes.Internal, "Error updating Service Account").Err()
 	}
-	// if we reach here, all is good, commit
-	if err := appCtx.Commit(); err != nil {
-		return nil, err
-	}
 
 	// get all the updated permissions for the service account
 	newPerms, err := cluster.GetAllThePermissionForServiceAccount(appCtx, &serviceAccount.ID)
@@ -206,6 +202,11 @@ func (s *server) UpdateServiceAccount(ctx context.Context, in *pb.UpdateServiceA
 	if err != nil {
 		log.Println(err.Error())
 		return nil, status.New(codes.Internal, "Internal error").Err()
+	}
+
+	// if we reach here, all is good, commit
+	if err := appCtx.Commit(); err != nil {
+		return nil, err
 	}
 
 	servAccountsResp := &pb.ServiceAccount{

--- a/api/api-public-user-grpc.go
+++ b/api/api-public-user-grpc.go
@@ -124,7 +124,7 @@ func (s *server) UserResetPasswordInvite(ctx context.Context, in *pb.InviteReque
 	}
 
 	// Send email invitation with token
-	err = cluster.InviteUserByEmail(appCtx, cluster.TokenResetPasswordEmail, &user)
+	err = cluster.InviteUserByEmail(appCtx, cluster.TokenResetPasswordEmail, user)
 	if err != nil {
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}
@@ -240,7 +240,7 @@ func (s *server) ChangePassword(ctx context.Context, in *pb.ChangePasswordReques
 		return nil, status.New(codes.Internal, err.Error()).Err()
 	}
 	// Invalidate all user's sessions
-	sessions, err := cluster.GetUserSessionsFromDB(appCtx, &userObj, cluster.SessionValid)
+	sessions, err := cluster.GetUserSessionsFromDB(appCtx, userObj, cluster.SessionValid)
 	if err != nil {
 		log.Println("Error getting user sessions from db: ", err)
 		return nil, status.New(codes.Internal, "error disabling user").Err()
@@ -290,7 +290,7 @@ func (s *server) DisableUser(ctx context.Context, in *pb.UserActionRequest) (*pb
 		log.Println("error disabling user on db: ", err)
 		return nil, status.New(codes.Internal, "error disabling user").Err()
 	}
-	sessions, err := cluster.GetUserSessionsFromDB(appCtx, &userObj, cluster.SessionValid)
+	sessions, err := cluster.GetUserSessionsFromDB(appCtx, userObj, cluster.SessionValid)
 	if err != nil {
 		log.Println("Error getting user sessions from db: ", err)
 		return nil, status.New(codes.Internal, "error disabling user").Err()

--- a/api/api-public-user-grpc.go
+++ b/api/api-public-user-grpc.go
@@ -41,6 +41,7 @@ func (s *server) UserWhoAmI(ctx context.Context, in *pb.Empty) (*pb.User, error)
 	if err != nil {
 		return nil, err
 	}
+	defer appCtx.Rollback()
 	// get User ID from context
 	userIDStr := ctx.Value(cluster.UserIDKey).(string)
 	userID, _ := uuid.FromString(userIDStr)

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -48,9 +48,8 @@ func AdminAuthInterceptor(ctx context.Context, req interface{}, info *grpc.Unary
 		log.Println("No token")
 		return nil, err
 	}
-
 	// validate admin session Token
-	adminToken, err := cluster.GetAdminSessionDetails(nil, &token)
+	adminToken, err := cluster.GetAdminSessionDetails(&token)
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "invalid token")
 	}
@@ -89,7 +88,7 @@ func PublicAuthInterceptor(ctx context.Context, req interface{}, info *grpc.Unar
 		return nil, status.Errorf(codes.Unauthenticated, "invalid token.")
 	}
 	// attempt to identify the user for the context
-	tenant, err := cluster.GetTenantByID(&validSession.TenantID)
+	tenant, err := cluster.GetTenantWithCtxByID(appCtx, &validSession.TenantID)
 	if err != nil {
 		log.Println(err)
 		return nil, status.New(codes.Internal, "internal error").Err()

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -82,7 +82,7 @@ func PublicAuthInterceptor(ctx context.Context, req interface{}, info *grpc.Unar
 	}
 
 	// attempt to validate the session
-	validSession, err := validateSessionID(appCtx, ctx)
+	validSession, err := validateSessionID(ctx, appCtx)
 	if err != nil || validSession == nil {
 		log.Println("Invalid session.", err)
 		return nil, status.Errorf(codes.Unauthenticated, "invalid token.")

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -75,7 +75,7 @@ func PublicAuthInterceptor(ctx context.Context, req interface{}, info *grpc.Unar
 		return handler(ctx, req)
 	}
 
-	appCtx, err := cluster.NewEmptyContext()
+	appCtx, err := cluster.NewEmptyContextWithGrpcContext(ctx)
 	if err != nil {
 		log.Println(err)
 		return nil, status.New(codes.Internal, "internal error").Err()

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -98,7 +98,7 @@ func PublicAuthInterceptor(ctx context.Context, req interface{}, info *grpc.Unar
 		log.Printf("Attempted access for tenant `%s` by user_id `%s`", tenant.ShortName, validSession.ID)
 		return nil, status.New(codes.Unauthenticated, "Account is disabled").Err()
 	}
-	if err := appCtx.SetTenant(&tenant); err != nil {
+	if err := appCtx.SetTenant(tenant); err != nil {
 		return nil, status.New(codes.Internal, "internal error").Err()
 	}
 	user, err := cluster.GetUserByID(appCtx, validSession.UserID)

--- a/api/authentication/utils.go
+++ b/api/authentication/utils.go
@@ -52,11 +52,11 @@ func getHeaderFromRequest(ctx context.Context, key string) (keyValue string, err
 
 // validateSessionId validates the sessionID available in the grpc metadata
 // headers and returns the session row id and the tenant short name
-func validateSessionID(ctx context.Context) (*cluster.Session, error) {
-	sessionID, err := getHeaderFromRequest(ctx, "sessionId")
+func validateSessionID(ctx *cluster.Context, reqCtx context.Context) (*cluster.Session, error) {
+	sessionID, err := getHeaderFromRequest(reqCtx, "sessionId")
 	if err != nil {
 		return nil, status.New(codes.InvalidArgument, err.Error()).Err()
 	}
-	session, err := cluster.GetValidSession(sessionID)
+	session, err := cluster.GetValidSession(ctx, sessionID)
 	return session, err
 }

--- a/api/authentication/utils.go
+++ b/api/authentication/utils.go
@@ -52,11 +52,11 @@ func getHeaderFromRequest(ctx context.Context, key string) (keyValue string, err
 
 // validateSessionId validates the sessionID available in the grpc metadata
 // headers and returns the session row id and the tenant short name
-func validateSessionID(ctx *cluster.Context, reqCtx context.Context) (*cluster.Session, error) {
-	sessionID, err := getHeaderFromRequest(reqCtx, "sessionId")
+func validateSessionID(ctx context.Context, appCtx *cluster.Context) (*cluster.Session, error) {
+	sessionID, err := getHeaderFromRequest(ctx, "sessionId")
 	if err != nil {
 		return nil, status.New(codes.InvalidArgument, err.Error()).Err()
 	}
-	session, err := cluster.GetValidSession(ctx, sessionID)
+	session, err := cluster.GetValidSession(appCtx, sessionID)
 	return session, err
 }

--- a/api/utils.go
+++ b/api/utils.go
@@ -18,27 +18,22 @@ package api
 
 import (
 	"context"
-	"log"
 
 	"github.com/minio/m3/cluster"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func getContextIfValidTenant(grpcCtx context.Context, tenantDomain string) (*cluster.Context, error) {
-	appCtx, err := cluster.NewTenantContextWithGrpcContext(grpcCtx)
+	appCtx, err := cluster.NewEmptyContextWithGrpcContext(grpcCtx)
 	if err != nil {
-		log.Println(err)
-		return nil, status.New(codes.Internal, "Internal Error").Err()
+		return nil, err
 	}
 	// validate tenant
 	tenant, err := cluster.GetTenantByDomainWithCtx(appCtx, tenantDomain)
 	if err != nil {
-		log.Println(err)
 		return nil, err
 	}
-	if err := appCtx.SetTenant(&tenant); err != nil {
-		return nil, status.New(codes.Internal, "Internal Error").Err()
+	if err := appCtx.SetTenant(tenant); err != nil {
+		return nil, err
 	}
 	return appCtx, nil
 }

--- a/cluster/admin-tokens.go
+++ b/cluster/admin-tokens.go
@@ -93,10 +93,12 @@ func MarkAdminTokenConsumed(ctx *Context, AdminTokenID *uuid.UUID) error {
 
 // CompleteSignup takes a urlToken and a password and changes the user password and then marks the token as used
 func SetAdminPasswordAction(ctx *Context, tokenID *uuid.UUID, password string) error {
-
 	adminToken, err := GetAdminTokenDetails(ctx, tokenID)
 	if err != nil {
-		return err
+		if err == ErrNoAdminToken {
+			return errors.New("invalid admin token")
+		}
+		return errors.New("Internal error")
 	}
 	if adminToken.Consumed {
 		return errors.New("admin token has already been consumed")

--- a/cluster/admins.go
+++ b/cluster/admins.go
@@ -21,8 +21,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/minio/m3/cluster/db"
-
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -100,12 +98,8 @@ func InsertAdmin(ctx *Context, admin *Admin) error {
 				admins ("id", "name", "email", "password","sys_created_by")
 			  VALUES
 				($1, $2, $3, $4, $5)`
-	tx, err := ctx.MainTx()
-	if err != nil {
-		return err
-	}
 	// Execute query
-	_, err = tx.Exec(query, admin.ID, admin.Name, admin.Email, hashedPassword, ctx.WhoAmI)
+	_, err = ctx.MainTx().Exec(query, admin.ID, admin.Name, admin.Email, hashedPassword, ctx.WhoAmI)
 	if err != nil {
 		return err
 	}
@@ -132,12 +126,8 @@ func setAdminPassword(ctx *Context, adminID *uuid.UUID, password string) error {
 	}
 
 	query := `UPDATE admins SET password=$1 WHERE id=$2`
-	tx, err := ctx.MainTx()
-	if err != nil {
-		return err
-	}
 	// Execute query
-	_, err = tx.Exec(query, hashedPassword, adminID)
+	_, err = ctx.MainTx().Exec(query, hashedPassword, adminID)
 	if err != nil {
 		return err
 	}
@@ -155,7 +145,7 @@ func GetAdminByEmail(ctx *Context, email string) (*Admin, error) {
 				admins t1
 			WHERE email=$1 LIMIT 1`
 
-	row := db.GetInstance().Db.QueryRow(queryUser, email)
+	row := ctx.MainTx().QueryRow(queryUser, email)
 
 	admin := Admin{}
 

--- a/cluster/admins.go
+++ b/cluster/admins.go
@@ -73,7 +73,7 @@ func AddAdminAction(ctx *Context, name string, adminEmail string) (*Admin, error
 		CliCommand: getCliCommand(),
 	}
 	// Get the mailing template for inviting users
-	body, err := GetTemplate("new-admin", templateData)
+	body, err := GetTemplate(ctx, "new-admin", templateData)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/buckets.go
+++ b/cluster/buckets.go
@@ -43,7 +43,7 @@ const (
 
 // MakeBucket will get the credentials for a given tenant and use the operator keys to create a bucket using minio-go
 // TODO: allow to spcify the user performing the action (like in the API/gRPC case)
-func MakeBucket(ctx *Context, tenantShortname, bucketName string, accessType BucketAccess) error {
+func MakeBucket(ctx *Context, bucketName string, accessType BucketAccess) error {
 	// validate bucket name
 	if bucketName != "" {
 		var re = regexp.MustCompile(`^[a-z0-9-]{3,}$`)

--- a/cluster/buckets.go
+++ b/cluster/buckets.go
@@ -68,11 +68,6 @@ func MakeBucket(ctx *Context, bucketName string, accessType BucketAccess) error 
 		return tagErrorAsMinio("MakeBucketWithContext", err)
 	}
 
-	//if err = addMinioBucketNotification(minioClient, bucketName, "us-east-1"); err != nil {
-	//	log.Println(err)
-	//	return tagErrorAsMinio("addMinioBucketNotification", err)
-	//}
-
 	err = SetBucketAccess(minioClient, bucketName, accessType)
 	if err != nil {
 		log.Println(err)

--- a/cluster/buckets.go
+++ b/cluster/buckets.go
@@ -53,7 +53,7 @@ func MakeBucket(ctx *Context, tenantShortname, bucketName string, accessType Buc
 	}
 
 	// Get tenant specific MinIO client
-	minioClient, err := newTenantMinioClient(nil, tenantShortname)
+	minioClient, err := newTenantMinioClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -111,9 +111,9 @@ func SetBucketAccess(minioClient *minio.Client, bucketName string, accessType Bu
 }
 
 // ChangeBucketAccess changes access type assigned to the given bucket
-func ChangeBucketAccess(tenantShortname, bucketName string, accessType BucketAccess) error {
+func ChangeBucketAccess(ctx *Context, bucketName string, accessType BucketAccess) error {
 	// Get tenant specific MinIO client
-	minioClient, err := newTenantMinioClient(nil, tenantShortname)
+	minioClient, err := newTenantMinioClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -153,9 +153,9 @@ func GetBucketAccess(minioClient *minio.Client, bucketName string) (BucketAccess
 }
 
 // ListBuckets for the given tenant's short name
-func ListBuckets(tenantShortname string) ([]TenantBucketInfo, error) {
+func ListBuckets(ctx *Context) ([]TenantBucketInfo, error) {
 	// Get tenant specific MinIO client
-	minioClient, err := newTenantMinioClient(nil, tenantShortname)
+	minioClient, err := newTenantMinioClient(ctx)
 	if err != nil {
 		return []TenantBucketInfo{}, err
 	}
@@ -180,9 +180,9 @@ func ListBuckets(tenantShortname string) ([]TenantBucketInfo, error) {
 }
 
 // Deletes a bucket in the given tenant's MinIO
-func DeleteBucket(tenantShortname, bucket string) error {
+func DeleteBucket(ctx *Context, bucket string) error {
 	// Get tenant specific MinIO client
-	minioClient, err := newTenantMinioClient(nil, tenantShortname)
+	minioClient, err := newTenantMinioClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cluster/buckets.go
+++ b/cluster/buckets.go
@@ -541,7 +541,7 @@ func CalculateTenantsMetrics() error {
 	if err != nil {
 		return err
 	}
-
+	defer appCtx.Rollback()
 	// restrict how many tenants will be placed in the channel at any given time, this is to avoid massive
 	// concurrent processing
 	var maxChannelSize int
@@ -563,13 +563,12 @@ func CalculateTenantsMetrics() error {
 		}
 		err := getTenantMetrics(appCtx, tenantResult.Tenant)
 		if err != nil {
-			appCtx.Rollback()
 			return err
 		}
-		err = appCtx.Commit()
-		if err != nil {
-			return err
-		}
+	}
+	err = appCtx.Commit()
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/cluster/buckets.go
+++ b/cluster/buckets.go
@@ -68,10 +68,10 @@ func MakeBucket(ctx *Context, bucketName string, accessType BucketAccess) error 
 		return tagErrorAsMinio("MakeBucketWithContext", err)
 	}
 
-	if err = addMinioBucketNotification(minioClient, bucketName, "us-east-1"); err != nil {
-		log.Println(err)
-		return tagErrorAsMinio("addMinioBucketNotification", err)
-	}
+	//if err = addMinioBucketNotification(minioClient, bucketName, "us-east-1"); err != nil {
+	//	log.Println(err)
+	//	return tagErrorAsMinio("addMinioBucketNotification", err)
+	//}
 
 	err = SetBucketAccess(minioClient, bucketName, accessType)
 	if err != nil {
@@ -327,14 +327,13 @@ func GetLatestBucketsSizes(ctx *Context) (bucketsSizes map[string]uint64, err er
 					buckets_sizes
 				FROM bucket_metrics s
 				ORDER BY last_update DESC`
-	tx, err := ctx.TenantTx()
 	if err != nil {
 		return bucketsSizes, err
 	}
 	// Get first result of the query which contains the latest number of
 	// buckets during the selected period one Month
 	var sizesRow []byte
-	row := tx.QueryRow(query)
+	row := ctx.TenantTx().QueryRow(query)
 	if err != nil {
 		return bucketsSizes, err
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -406,7 +406,7 @@ func ProvisionTenantOnStorageGroup(ctx *Context, tenant *Tenant, sg *StorageGrou
 			}
 		}
 		// Create Tenant artifacts
-		if err := createTenantConfigMap(ctx, sgTenantResult.StorageGroupTenant); err != nil {
+		if err := createTenantConfigMap(sgTenantResult.StorageGroupTenant); err != nil {
 			ch <- &StorageGroupTenantResult{
 				Error: err,
 			}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -406,7 +406,7 @@ func ProvisionTenantOnStorageGroup(ctx *Context, tenant *Tenant, sg *StorageGrou
 			}
 		}
 		// Create Tenant artifacts
-		if err := createTenantConfigMap(sgTenantResult.StorageGroupTenant); err != nil {
+		if err := createTenantConfigMap(ctx, sgTenantResult.StorageGroupTenant); err != nil {
 			ch <- &StorageGroupTenantResult{
 				Error: err,
 			}

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -98,3 +98,12 @@ func getAppURL() string {
 func getCliCommand() string {
 	return env.Get("CLI_COMMAND", "m3")
 }
+
+// getGlobalBucketsCfg returns the config state of global buckets, if there's no config, it returns false
+func getGlobalBucketsCfg() bool {
+	globalBuckets, err := GetConfig(cfgCoreGlobalBuckets)
+	if err != nil || globalBuckets == nil {
+		return false
+	}
+	return globalBuckets.ValBool()
+}

--- a/cluster/configuration.go
+++ b/cluster/configuration.go
@@ -19,6 +19,8 @@ package cluster
 import (
 	"errors"
 	"log"
+
+	"github.com/minio/m3/cluster/db"
 )
 
 type Configuration struct {
@@ -63,7 +65,7 @@ func SetConfigWithLock(ctx *Context, key, val, valType string, locked bool) erro
 	return nil
 }
 
-func GetConfig(ctx *Context, key string, fallback interface{}) (*Configuration, error) {
+func GetConfig(key string, fallback interface{}) (*Configuration, error) {
 	query :=
 		`SELECT 
 				c.key, c.value, c.type, c.locked
@@ -71,7 +73,7 @@ func GetConfig(ctx *Context, key string, fallback interface{}) (*Configuration, 
 				configurations c
 			WHERE c.key=$1`
 	// non-transactional query
-	row := ctx.MainTx().QueryRow(query, key)
+	row := db.GetInstance().MainDB().QueryRow(query, key)
 	config := Configuration{}
 	// Save the resulted query on the User struct
 	err := row.Scan(&config.Key, &config.Value, &config.ValueType, &config.locked)

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -82,8 +82,8 @@ func (c *Context) Commit() error {
 
 func (c *Context) BeginTx() error {
 	// being tenant schema tx
-	if c.tenantTx == nil && c.Tenant != nil {
-		tenantTx, err := startTenantTx(c.ControlCtx, c.Tenant())
+	if c.tenantTx == nil && c.tenant != nil {
+		tenantTx, err := startTenantTx(c.ControlCtx, c.tenant)
 		if err != nil {
 			return err
 		}

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -226,7 +226,7 @@ func NewTenantContextWithGrpcContext(ctx context.Context) (*Context, error) {
 		return nil, status.New(codes.Internal, "internal error").Err()
 	}
 	// set the tenant on the context
-	if err := appCtx.SetTenant(&tenant); err != nil {
+	if err := appCtx.SetTenant(tenant); err != nil {
 		return nil, status.New(codes.Internal, "internal error").Err()
 	}
 

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -164,12 +164,11 @@ func NewEmptyContextWithGrpcContext(ctx context.Context) (*Context, error) {
 // autoRollback startws a go routine that monitors the control context to attempt a rollback
 func (c *Context) autoRollback() {
 	go func() {
-		select {
-		case <-c.ControlCtx.Done():
-			if err := c.Rollback(); err != nil {
-				if err != sql.ErrTxDone {
-					log.Println(err)
-				}
+		// block until done
+		<-c.ControlCtx.Done()
+		if err := c.Rollback(); err != nil {
+			if err != sql.ErrTxDone {
+				log.Println(err)
 			}
 		}
 	}()

--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -81,12 +81,8 @@ func createUserWithCredentials(ctx *Context, tenantShortName string, userdID uui
 				credentials ("access_key", "user_id", "ui_credential", "sys_created_by")
 			  VALUES
 				($1, $2, $3, $4)`
-	tx, err := ctx.TenantTx()
-	if err != nil {
-		return err
-	}
 	// Execute query
-	_, err = tx.Exec(query, userUICredentials.AccessKey, userdID, true, ctx.WhoAmI)
+	_, err = ctx.TenantTx().Exec(query, userUICredentials.AccessKey, userdID, true, ctx.WhoAmI)
 	if err != nil {
 		return err
 	}
@@ -180,12 +176,8 @@ func createServiceAccountCredentials(ctx *Context, tenantShortName string, servi
 				credentials ("access_key","service_account_id","ui_credential","sys_created_by")
 			  VALUES
 				($1,$2,$3,$4)`
-	tx, err := ctx.TenantTx()
-	if err != nil {
-		return nil, err
-	}
 	// Execute query
-	_, err = tx.Exec(query, saCredentials.AccessKey, serviceAccountID, false, ctx.WhoAmI)
+	_, err = ctx.TenantTx().Exec(query, saCredentials.AccessKey, serviceAccountID, false, ctx.WhoAmI)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +196,7 @@ func GetCredentialsForServiceAccount(ctx *Context, serviceAccountID *uuid.UUID) 
 				LEFT JOIN service_accounts sa ON c.service_account_id = sa.id
 			WHERE sa.id=$1 LIMIT 1`
 
-	row := ctx.TenantDB().QueryRow(queryUser, serviceAccountID)
+	row := ctx.TenantTx().QueryRow(queryUser, serviceAccountID)
 	sac := ServiceAccountCredentials{}
 	// Save the resulted query on the User struct
 	err := row.Scan(&sac.AccessKey)

--- a/cluster/db/connections.go
+++ b/cluster/db/connections.go
@@ -124,7 +124,6 @@ func ConnectToDb(ctx context.Context, config *Config) chan CnxResult {
 				ch <- CnxResult{Error: err}
 				return
 			}
-			log.Printf("CONNECTING TO DB %s\n", config.Name)
 			ch <- CnxResult{Cnx: db}
 		}
 	}()
@@ -140,7 +139,6 @@ func (s *Singleton) GetTenantDB(tenantName string) *sql.DB {
 		//do something here
 		return db
 	}
-	log.Printf("Connection for `%s` not found, opening new connection.", tenantName)
 	// if we reach this point, there was no connection in cache, connect and return the connection
 	ctx := context.Background()
 	// Get the tenant DB configuration

--- a/cluster/db/connections.go
+++ b/cluster/db/connections.go
@@ -185,3 +185,7 @@ func (s *Singleton) StartMainTx(controlCtx context.Context) (*sql.Tx, error) {
 	}
 	return tx, nil
 }
+
+func (s *Singleton) MainDB() *sql.DB {
+	return s.db
+}

--- a/cluster/db/connections.go
+++ b/cluster/db/connections.go
@@ -180,7 +180,6 @@ func (s *Singleton) Close() error {
 
 // Close all connectiosn
 func (s *Singleton) StartMainTx(controlCtx context.Context) (*sql.Tx, error) {
-	log.Println("----Started new main tx")
 	tx, err := s.db.BeginTx(controlCtx, nil)
 	if err != nil {
 		return nil, err

--- a/cluster/db/connections.go
+++ b/cluster/db/connections.go
@@ -124,6 +124,7 @@ func ConnectToDb(ctx context.Context, config *Config) chan CnxResult {
 				ch <- CnxResult{Error: err}
 				return
 			}
+			log.Printf("CONNECTING TO DB %s\n", config.Name)
 			ch <- CnxResult{Cnx: db}
 		}
 	}()
@@ -179,6 +180,7 @@ func (s *Singleton) Close() error {
 
 // Close all connectiosn
 func (s *Singleton) StartMainTx(controlCtx context.Context) (*sql.Tx, error) {
+	log.Println("----Started new main tx")
 	tx, err := s.db.BeginTx(controlCtx, nil)
 	if err != nil {
 		return nil, err

--- a/cluster/email.go
+++ b/cluster/email.go
@@ -130,14 +130,14 @@ func SendMail(toName, toEmail, subject, body string) error {
 }
 
 // GetTemplate gets a template from the templates folder and applies the template date
-func GetTemplate(templateName string, data interface{}) (*string, error) {
+func GetTemplate(ctx *Context, templateName string, data interface{}) (*string, error) {
 	// validate that the template is only alpha numerical stuff
 	var re = regexp.MustCompile(`^[a-z0-9-]{2,}$`)
 	if !re.MatchString(templateName) {
 		return nil, errors.New("invalid template name")
 	}
 	// try to load the template from the db
-	dbTemplate, err := getTemplateFromDB(nil, templateName)
+	dbTemplate, err := getTemplateFromDB(ctx, templateName)
 	if err != nil {
 		// ignore no results error
 		if !strings.Contains(err.Error(), "no rows in result set") {

--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -320,12 +320,16 @@ func WatcEtcdBucketCreation(ctx *Context) {
 				err = processMessage(ctx, event)
 				if err != nil {
 					log.Println("error processing event", err)
-					ctx.Rollback()
+					if err := ctx.Rollback(); err != nil {
+						log.Println(err)
+					}
 					return
 				}
-				ctx.Commit()
 				// announce the bucket on the router
 				<-UpdateNginxConfiguration(ctx)
+				if err := ctx.Commit(); err != nil {
+					log.Println(err)
+				}
 			}(event)
 		}
 	}

--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -270,11 +270,7 @@ func getEtcdCRDDeployment(clusterName string) *unstructured.Unstructured {
 
 // WatcEtcdBucketCreation watches a key prefix on etcd for new buckets being created
 func WatcEtcdBucketCreation(ctx *Context) {
-	globalBuckets, err := GetConfig(cfgCoreGlobalBuckets, false)
-	if err != nil {
-		return
-	}
-	if globalBuckets.ValBool() {
+	if getGlobalBucketsCfg() {
 		log.Println("Global buckets is ON")
 	} else {
 		log.Println("Global buckets is OFF")
@@ -285,6 +281,7 @@ func WatcEtcdBucketCreation(ctx *Context) {
 	etcdWatchKey := "/skydns"
 
 	var etcd *clientv3.Client
+	var err error
 	tries := 0
 	for {
 		etcd, err = clientv3.New(clientv3.Config{

--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -269,8 +269,8 @@ func getEtcdCRDDeployment(clusterName string) *unstructured.Unstructured {
 }
 
 // WatcEtcdBucketCreation watches a key prefix on etcd for new buckets being created
-func WatcEtcdBucketCreation() {
-	globalBuckets, err := GetConfig(nil, cfgCoreGlobalBuckets, false)
+func WatcEtcdBucketCreation(ctx *Context) {
+	globalBuckets, err := GetConfig(ctx, cfgCoreGlobalBuckets, false)
 	if err != nil {
 		return
 	}
@@ -370,7 +370,7 @@ func processMessage(ctx *Context, event *clientv3.Event) error {
 		if err != nil {
 			return err
 		}
-		tenant, err := GetTenantWithCtxByServiceName(nil, keyParts.TenantShortName)
+		tenant, err := GetTenantWithCtxByServiceName(ctx, keyParts.TenantShortName)
 		if err != nil {
 			return err
 		}
@@ -386,7 +386,7 @@ func processMessage(ctx *Context, event *clientv3.Event) error {
 			return err
 		}
 
-		tenant, err := GetTenantWithCtxByServiceName(nil, keyParts.TenantShortName)
+		tenant, err := GetTenantWithCtxByServiceName(ctx, keyParts.TenantShortName)
 		if err != nil {
 			return err
 		}

--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -320,7 +320,6 @@ func WatcEtcdBucketCreation(ctx *Context) {
 					if err := ctx.Rollback(); err != nil {
 						log.Println(err)
 					}
-					log.Println("ROLLING BACK")
 					return
 				}
 				log.Println("error state:", err)

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -17,14 +17,12 @@
 package cluster
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"time"
 
 	"github.com/minio/m3/cluster/db"
 
-	"github.com/minio/minio-go/v6"
 	"github.com/minio/minio/pkg/env"
 	"github.com/minio/minio/pkg/madmin"
 )
@@ -170,27 +168,6 @@ func getPostgresNotificationMinioConfigKV() (config string) {
 		dbConfg.Pwd,
 		dbConfg.Name)
 	return config
-}
-
-// addMinioBucketNotification
-func addMinioBucketNotification(minioClient *minio.Client, bucketName, region string) error {
-	postgresTable := env.Get("M3_POSTGRES_NOTIFICATION_TABLE", "bucketevents")
-	queueArn := minio.NewArn("minio", "sqs", region, postgresTable, "postgresql")
-	queueConfig := minio.NewNotificationConfig(queueArn)
-	queueConfig.AddEvents(minio.ObjectCreatedAll, minio.ObjectRemovedAll)
-
-	bucketNotification := minio.BucketNotification{}
-	bucketNotification.AddQueue(queueConfig)
-
-	// Setting notification is a fast process, set the timeout to maximum 5 secs.
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-
-	err := minioClient.SetBucketNotificationWithContext(timeoutCtx, bucketName, bucketNotification)
-	if err != nil {
-		return tagErrorAsMinio("SetBucketNotificationWithContext", err)
-	}
-	return nil
 }
 
 // tagErrorAsMinio takes an error and tags it as a MinIO error

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -203,7 +203,7 @@ func tagErrorAsMinio(what string, err error) error {
 // minioIsReady determines whether the MinIO for a tenant is ready or not
 func minioIsReady(ctx *Context) (bool, error) {
 	// Get tenant specific MinIO client
-	minioClient, err := newTenantMinioClient(ctx, ctx.Tenant.ShortName)
+	minioClient, err := newTenantMinioClient(ctx, ctx.Tenant().ShortName)
 	if err != nil {
 		return false, err
 	}

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -203,7 +203,7 @@ func tagErrorAsMinio(what string, err error) error {
 // minioIsReady determines whether the MinIO for a tenant is ready or not
 func minioIsReady(ctx *Context) (bool, error) {
 	// Get tenant specific MinIO client
-	minioClient, err := newTenantMinioClient(ctx, ctx.Tenant().ShortName)
+	minioClient, err := newTenantMinioClient(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/cluster/nginx.go
+++ b/cluster/nginx.go
@@ -224,7 +224,7 @@ func UpdateNginxConfiguration(ctx *Context) chan error {
 			return
 		}
 		if globalBuckets.ValBool() {
-			nginxConfiguration = getGlobalBucketNamespaceConfiguration()
+			nginxConfiguration = getGlobalBucketNamespaceConfiguration(ctx)
 		} else {
 			nginxConfiguration = getLocalBucketNamespaceConfiguration(ctx)
 		}
@@ -315,10 +315,10 @@ func getLocalBucketNamespaceConfiguration(ctx *Context) string {
 }
 
 // getGlobalBucketNamespaceConfiguration build the nginx configuration for global bucket name space
-func getGlobalBucketNamespaceConfiguration() string {
+func getGlobalBucketNamespaceConfiguration(ctx *Context) string {
 	// build a list of upstreams for each tenant
 	var tenantUpstreams bytes.Buffer
-	tenantsStream := streamTenantService(10)
+	tenantsStream := streamTenantService(ctx, 10)
 	for tenantRes := range tenantsStream {
 		if tenantRes.Error != nil {
 			log.Println(tenantRes.Error)
@@ -339,7 +339,7 @@ func getGlobalBucketNamespaceConfiguration() string {
 
 	// build a mapping of access keys to upstreams (by tenant short name)
 	var destinationMapping bytes.Buffer
-	accessTenantStream := streamAccessKeyToTenantServices()
+	accessTenantStream := streamAccessKeyToTenantServices(ctx)
 	for accessTenantResult := range accessTenantStream {
 		if accessTenantResult.Error != nil {
 			log.Println(accessTenantResult.Error)
@@ -431,7 +431,7 @@ func getGlobalBucketNamespaceConfiguration() string {
 				}
 		`, appDomain))
 
-	bucketRoutes := streamBucketToTenantServices()
+	bucketRoutes := streamBucketToTenantServices(ctx)
 	for bucketRouteResult := range bucketRoutes {
 		if bucketRouteResult.Error != nil {
 			log.Println(bucketRouteResult.Error)

--- a/cluster/nginx.go
+++ b/cluster/nginx.go
@@ -218,7 +218,7 @@ func UpdateNginxConfiguration(ctx *Context) chan error {
 
 		var nginxConfiguration string
 		// check whether global buckets are enabled
-		globalBuckets, err := GetConfig(nil, cfgCoreGlobalBuckets, false)
+		globalBuckets, err := GetConfig(ctx, cfgCoreGlobalBuckets, false)
 		if err != nil {
 			ch <- err
 			return

--- a/cluster/nginx.go
+++ b/cluster/nginx.go
@@ -218,7 +218,7 @@ func UpdateNginxConfiguration(ctx *Context) chan error {
 
 		var nginxConfiguration string
 		// check whether global buckets are enabled
-		globalBuckets, err := GetConfig(ctx, cfgCoreGlobalBuckets, false)
+		globalBuckets, err := GetConfig(cfgCoreGlobalBuckets, false)
 		if err != nil {
 			ch <- err
 			return

--- a/cluster/nginx.go
+++ b/cluster/nginx.go
@@ -218,12 +218,7 @@ func UpdateNginxConfiguration(ctx *Context) chan error {
 
 		var nginxConfiguration string
 		// check whether global buckets are enabled
-		globalBuckets, err := GetConfig(cfgCoreGlobalBuckets, false)
-		if err != nil {
-			ch <- err
-			return
-		}
-		if globalBuckets.ValBool() {
+		if getGlobalBucketsCfg() {
 			nginxConfiguration = getGlobalBucketNamespaceConfiguration(ctx)
 		} else {
 			nginxConfiguration = getLocalBucketNamespaceConfiguration(ctx)

--- a/cluster/scheduler.go
+++ b/cluster/scheduler.go
@@ -63,6 +63,10 @@ func StartScheduler() {
 		panic(err)
 	}
 	for {
+		// start new transaction so the loop continues
+		if err := ctx.BeginTx(); err != nil {
+			panic(err)
+		}
 		task, err := fetchNewTask(ctx)
 		if err != nil && err != sql.ErrNoRows {
 			// panic if we can't fetch tasks
@@ -81,11 +85,8 @@ func StartScheduler() {
 			if err := ctx.Commit(); err != nil {
 				panic(err)
 			}
-			// start new transaction so the loop continues
-			if err := ctx.BeginTx(); err != nil {
-				panic(err)
-			}
 		} else {
+			ctx.Rollback()
 			// we got not task, sleep a little
 			time.Sleep(time.Millisecond * 500)
 		}

--- a/cluster/setup.go
+++ b/cluster/setup.go
@@ -157,7 +157,7 @@ func SetupM3() error {
 		return err
 	}
 
-	err = SetupDBAction(appCtx)
+	err = SetupDBAction()
 	if err != nil {
 		log.Println(err)
 		return err
@@ -199,14 +199,14 @@ func SetupM3() error {
 }
 
 // SetupDBAction runs all the operations to setup the DB or migrate it
-func SetupDBAction(ctx *Context) error {
+func SetupDBAction() error {
 	// setup the tenants shared db
-	err := CreateProvisioningSchema(ctx)
+	err := CreateProvisioningSchema()
 	if err != nil {
 		// this error could be because the database already exists, so we are going to tolerate it.
 		log.Println(err)
 	}
-	err = CreateTenantsSharedDatabase(ctx)
+	err = CreateTenantsSharedDatabase()
 	if err != nil {
 		// this error could be because the database already exists, so we are going to tolerate it.
 		log.Println(err)
@@ -479,12 +479,13 @@ func RunMigrations() error {
 }
 
 // CreateTenantSchema creates a db schema for the tenant
-func CreateTenantsSharedDatabase(ctx *Context) error {
+func CreateTenantsSharedDatabase() error {
 
 	// format in the tenant name assuming it's safe
 	query := fmt.Sprintf(`CREATE DATABASE %s`, env.Get("M3_TENANTS_DB", "tenants"))
 
-	_, err := ctx.MainTx().Exec(query)
+	// we cannot create a DB inside a transaction
+	_, err := db.GetInstance().MainDB().Exec(query)
 	if err != nil {
 		return err
 	}
@@ -492,11 +493,11 @@ func CreateTenantsSharedDatabase(ctx *Context) error {
 }
 
 // CreateProvisioningSchema creates a db schema for provisioning
-func CreateProvisioningSchema(ctx *Context) error {
+func CreateProvisioningSchema() error {
 	// format in the tenant name assuming it's safe
 	query := `CREATE SCHEMA provisioning`
 
-	_, err := ctx.MainTx().Exec(query)
+	_, err := db.GetInstance().MainDB().Exec(query)
 	if err != nil {
 		return err
 	}

--- a/cluster/storage-cluster.go
+++ b/cluster/storage-cluster.go
@@ -299,6 +299,7 @@ func GetListOfTenantsForStorageGroup(ctx *Context, sg *StorageGroup) chan []*Sto
 			fmt.Println(err)
 			return
 		}
+		defer rows.Close()
 		var tenants []*StorageGroupTenant
 		for rows.Next() {
 			var tenantID uuid.UUID
@@ -321,6 +322,9 @@ func GetListOfTenantsForStorageGroup(ctx *Context, sg *StorageGroup) chan []*Sto
 				ServiceName:  serviceName,
 				StorageGroup: sg})
 
+		}
+		if err := rows.Err(); err != nil {
+			fmt.Println(err)
 		}
 		ch <- tenants
 	}()
@@ -348,6 +352,7 @@ func GetAllTenantRoutes(ctx *Context) chan []*TenantRoute {
 			fmt.Println(err)
 			return
 		}
+		defer rows.Close()
 		var tenants []*TenantRoute
 		for rows.Next() {
 			tr := TenantRoute{}

--- a/cluster/storage-cluster.go
+++ b/cluster/storage-cluster.go
@@ -540,8 +540,6 @@ func GetTenantStorageGroupByShortName(ctx *Context, tenantShortName string) chan
 			return
 		}
 		ch <- &StorageGroupTenantResult{Error: ErrNoTenantStorageGroup}
-		return
-
 	}()
 	return ch
 }

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -240,7 +240,7 @@ func GetUserByID(ctx *Context, id uuid.UUID) (*User, error) {
 				users t1
 			WHERE id=$1 LIMIT 1`
 
-	rows, err := ctx.TenantTx().Query(queryUser, email)
+	rows, err := ctx.TenantTx().Query(queryUser, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -318,7 +318,7 @@ func InviteUserByEmail(ctx *Context, usedFor string, user *User) error {
 	}
 
 	// Get the mailing template for inviting users
-	body, err := GetTemplate(emailTemplate, templateData)
+	body, err := GetTemplate(ctx, emailTemplate, templateData)
 	if err != nil {
 		return fmt.Errorf("template: %w", err)
 	}

--- a/cluster/tenant-users.go
+++ b/cluster/tenant-users.go
@@ -256,6 +256,7 @@ func GetUsersForTenant(ctx *Context, offset int32, limit int32) ([]*User, error)
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	var users []*User
 	for rows.Next() {
 		usr := User{}
@@ -264,6 +265,9 @@ func GetUsersForTenant(ctx *Context, offset int32, limit int32) ([]*User, error)
 			return nil, err
 		}
 		users = append(users, &usr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return users, nil
 }

--- a/cluster/tenants.go
+++ b/cluster/tenants.go
@@ -56,6 +56,8 @@ const (
 	TenantAvailable = true
 )
 
+var ErrNoTenant = errors.New("no tenant found")
+
 func ProvisionTenants(ctx *Context, tenants []string, sg *StorageGroup) error {
 	for _, shortName := range tenants {
 		// Enable kes service for handling minio encryption
@@ -777,8 +779,6 @@ func createTenantConfigMap(sgTenant *StorageGroupTenant) error {
 
 // GetTenantWithCtxByServiceName gets the Tenant if it exists on the m3.provisining.tenants table
 // search is done by tenant service name
-var ErrNoTenant = errors.New("no tenant found")
-
 func GetTenantWithCtxByServiceName(ctx *Context, serviceName string) (*Tenant, error) {
 	query :=
 		`SELECT 

--- a/cluster/url-tokens.go
+++ b/cluster/url-tokens.go
@@ -117,7 +117,7 @@ func CompleteSignup(ctx *Context, urlToken *URLToken, password string) error {
 		log.Println("error getting user by id: ", err)
 		return err
 	}
-	sessions, err := GetUserSessionsFromDB(ctx, &userObj, SessionValid)
+	sessions, err := GetUserSessionsFromDB(ctx, userObj, SessionValid)
 	if err != nil {
 		log.Println("error getting user sessions from db: ", err)
 		return err

--- a/cluster/url-tokens.go
+++ b/cluster/url-tokens.go
@@ -57,7 +57,6 @@ func NewURLToken(ctx *Context, userID *uuid.UUID, usedFor string, validity *time
 
 // GetTenantTokenDetails get the details for the provided urlToken
 func GetTenantTokenDetails(ctx *Context, urlToken *uuid.UUID) (*URLToken, error) {
-
 	// Get an individual token
 	queryUser := `
 		SELECT 

--- a/cluster/url-tokens.go
+++ b/cluster/url-tokens.go
@@ -38,6 +38,8 @@ type URLToken struct {
 	Consumed   bool
 }
 
+var ErrNoURLToken = errors.New("tenant: No URL Token found")
+
 // NewURLToken generates and stores a new urlToken for the provided user, with the specified validity
 func NewURLToken(ctx *Context, userID *uuid.UUID, usedFor string, validity *time.Time) (*uuid.UUID, error) {
 	urlToken := uuid.NewV4()
@@ -52,8 +54,6 @@ func NewURLToken(ctx *Context, userID *uuid.UUID, usedFor string, validity *time
 	}
 	return &urlToken, nil
 }
-
-var ErrNoUrlToken = errors.New("tenant: No URL Token found")
 
 // GetTenantTokenDetails get the details for the provided urlToken
 func GetTenantTokenDetails(ctx *Context, urlToken *uuid.UUID) (*URLToken, error) {
@@ -84,7 +84,7 @@ func GetTenantTokenDetails(ctx *Context, urlToken *uuid.UUID) (*URLToken, error)
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	return nil, ErrNoUrlToken
+	return nil, ErrNoURLToken
 }
 
 // MarkTokenConsumed updates the record for the urlToken as is it has been used

--- a/cmd/m3/run-task.go
+++ b/cmd/m3/run-task.go
@@ -48,8 +48,13 @@ func runTask(ctx *cli.Context) error {
 			return errors.New("invalid error identifier")
 		}
 	}
+	appCtx, err := cluster.NewEmptyContext()
+	if err != nil {
+		log.Println(err)
+		return err
+	}
 	log.Printf("Runnnig task: %d\n", id)
-	if err := cluster.RunTask(id); err != nil {
+	if err := cluster.RunTask(appCtx, id); err != nil {
 		log.Println(err)
 		return err
 	}

--- a/cmd/m3/run-task.go
+++ b/cmd/m3/run-task.go
@@ -48,13 +48,8 @@ func runTask(ctx *cli.Context) error {
 			return errors.New("invalid error identifier")
 		}
 	}
-	appCtx, err := cluster.NewEmptyContext()
-	if err != nil {
-		log.Println(err)
-		return err
-	}
 	log.Printf("Runnnig task: %d\n", id)
-	if err := cluster.RunTask(appCtx, id); err != nil {
+	if err := cluster.RunTask(id); err != nil {
 		log.Println(err)
 		return err
 	}

--- a/cmd/m3/service.go
+++ b/cmd/m3/service.go
@@ -51,7 +51,13 @@ func startAPIServiceCmd(ctx *cli.Context) error {
 	metricsCh := cluster.RecurrentTenantMetricsCalculation()
 
 	go func() {
-		cluster.WatcEtcdBucketCreation()
+		appCtx, err := cluster.NewEmptyContext()
+		if err != nil {
+			log.Println("error starting etcd watch", err)
+			return
+		}
+
+		cluster.WatcEtcdBucketCreation(appCtx)
 	}()
 
 	select {

--- a/cmd/m3/signup.go
+++ b/cmd/m3/signup.go
@@ -78,7 +78,11 @@ func signup(ctx *cli.Context) error {
 		return err
 	}
 
-	appCtx := cluster.NewCtxWithTenant(&tenant)
+	appCtx, err := cluster.NewCtxWithTenant(&tenant)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
 
 	urlToken, err := cluster.GetTenantTokenDetails(appCtx, &parsedJwtToken.Token)
 	if err != nil {

--- a/cmd/m3/signup.go
+++ b/cmd/m3/signup.go
@@ -71,16 +71,21 @@ func signup(ctx *cli.Context) error {
 		return err
 	}
 
+	appCtx, err := cluster.NewEmptyContext()
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
 	// validate tenant
-	tenant, err := cluster.GetTenantByID(&parsedJwtToken.TenantID)
+	tenant, err := cluster.GetTenantWithCtxByID(appCtx, &parsedJwtToken.TenantID)
 	if err != nil {
 		log.Println(err)
 		return err
 	}
-
-	appCtx, err := cluster.NewCtxWithTenant(&tenant)
-	if err != nil {
-		fmt.Println(err)
+	// set the tenant to the context
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		log.Println(err)
 		return err
 	}
 

--- a/cmd/m3/signup.go
+++ b/cmd/m3/signup.go
@@ -84,7 +84,7 @@ func signup(ctx *cli.Context) error {
 		return err
 	}
 	// set the tenant to the context
-	if err := appCtx.SetTenant(&tenant); err != nil {
+	if err := appCtx.SetTenant(tenant); err != nil {
 		log.Println(err)
 		return err
 	}

--- a/cmd/m3/tenant-add.go
+++ b/cmd/m3/tenant-add.go
@@ -140,5 +140,6 @@ func addTenant(ctx *cli.Context) error {
 		bar.Add(int(resp.Progress))
 		fmt.Print(resp.Message)
 	}
+	fmt.Print("\n")
 	return nil
 }

--- a/cmd/m3/tenant-service-account-add.go
+++ b/cmd/m3/tenant-service-account-add.go
@@ -85,7 +85,11 @@ func tenantServiceAccountAdd(ctx *cli.Context) error {
 	}
 
 	// create context
-	appCtx := cluster.NewCtxWithTenant(&tenant)
+	appCtx, err := cluster.NewCtxWithTenant(&tenant)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
 
 	// perform the action
 	_, saCred, err := cluster.AddServiceAccount(appCtx, tenantDomain, name, desc)

--- a/cmd/m3/tenant-service-account-add.go
+++ b/cmd/m3/tenant-service-account-add.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/minio/cli"
 	"github.com/minio/m3/cluster"
@@ -78,16 +79,23 @@ func tenantServiceAccountAdd(ctx *cli.Context) error {
 	if description != "" {
 		desc = &description
 	}
+
+	// create context
+	appCtx, err := cluster.NewEmptyContext()
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
 	//validate tenant
-	tenant, err := cluster.GetTenantByDomain(tenantDomain)
+	tenant, err := cluster.GetTenantByDomainWithCtx(appCtx, tenantDomain)
 	if err != nil {
 		return err
 	}
 
-	// create context
-	appCtx, err := cluster.NewCtxWithTenant(&tenant)
-	if err != nil {
-		fmt.Println(err)
+	// set the tenant to the context
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		log.Println(err)
 		return err
 	}
 

--- a/cmd/m3/tenant-service-account-add.go
+++ b/cmd/m3/tenant-service-account-add.go
@@ -94,7 +94,7 @@ func tenantServiceAccountAdd(ctx *cli.Context) error {
 	}
 
 	// set the tenant to the context
-	if err := appCtx.SetTenant(&tenant); err != nil {
+	if err := appCtx.SetTenant(tenant); err != nil {
 		log.Println(err)
 		return err
 	}

--- a/cmd/m3/tenant-service-account-list.go
+++ b/cmd/m3/tenant-service-account-list.go
@@ -91,7 +91,11 @@ func tenantServiceAccountList(ctx *cli.Context) error {
 	}
 
 	// create context
-	appCtx := cluster.NewCtxWithTenant(&tenant)
+	appCtx, err := cluster.NewCtxWithTenant(&tenant)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
 
 	users, err := cluster.GetServiceAccountList(appCtx, offset, limit)
 	if err != nil {

--- a/cmd/m3/tenant-service-account-list.go
+++ b/cmd/m3/tenant-service-account-list.go
@@ -83,16 +83,22 @@ func tenantServiceAccountList(ctx *cli.Context) error {
 		fmt.Println("You must provide tenant name")
 		return errMissingArguments
 	}
+	// create context
+	appCtx, err := cluster.NewEmptyContext()
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
 	//validate tenant
-	tenant, err := cluster.GetTenantByDomain(tenantDomain)
+	tenant, err := cluster.GetTenantByDomainWithCtx(appCtx, tenantDomain)
 	if err != nil {
 		fmt.Println("Invalid tenant")
 		return err
 	}
 
-	// create context
-	appCtx, err := cluster.NewCtxWithTenant(&tenant)
-	if err != nil {
+	// set the tenant to the context
+	if err := appCtx.SetTenant(&tenant); err != nil {
 		fmt.Println(err)
 		return err
 	}

--- a/cmd/m3/tenant-service-account-list.go
+++ b/cmd/m3/tenant-service-account-list.go
@@ -98,7 +98,7 @@ func tenantServiceAccountList(ctx *cli.Context) error {
 	}
 
 	// set the tenant to the context
-	if err := appCtx.SetTenant(&tenant); err != nil {
+	if err := appCtx.SetTenant(tenant); err != nil {
 		fmt.Println(err)
 		return err
 	}

--- a/cmd/m3/tenant-user-list.go
+++ b/cmd/m3/tenant-user-list.go
@@ -90,7 +90,11 @@ func tenantUserList(ctx *cli.Context) error {
 	}
 
 	// create context
-	appCtx := cluster.NewCtxWithTenant(&tenant)
+	appCtx, err := cluster.NewCtxWithTenant(&tenant)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
 	// perform the action
 	users, err := cluster.GetUsersForTenant(appCtx, int32(offset), int32(limit))
 	if err != nil {

--- a/cmd/m3/tenant-user-list.go
+++ b/cmd/m3/tenant-user-list.go
@@ -96,7 +96,7 @@ func tenantUserList(ctx *cli.Context) error {
 		return err
 	}
 	// set the tenant to the context
-	if err := appCtx.SetTenant(&tenant); err != nil {
+	if err := appCtx.SetTenant(tenant); err != nil {
 		fmt.Println(err)
 		return err
 	}

--- a/cmd/m3/tenant-user-list.go
+++ b/cmd/m3/tenant-user-list.go
@@ -83,18 +83,24 @@ func tenantUserList(ctx *cli.Context) error {
 		fmt.Println("You must provide tenant name")
 		return errMissingArguments
 	}
-	//validate tenant
-	tenant, err := cluster.GetTenantByDomain(tenantDomain)
-	if err != nil {
-		return err
-	}
 
 	// create context
-	appCtx, err := cluster.NewCtxWithTenant(&tenant)
+	appCtx, err := cluster.NewEmptyContext()
 	if err != nil {
 		fmt.Println(err)
 		return err
 	}
+	//validate tenant
+	tenant, err := cluster.GetTenantByDomainWithCtx(appCtx, tenantDomain)
+	if err != nil {
+		return err
+	}
+	// set the tenant to the context
+	if err := appCtx.SetTenant(&tenant); err != nil {
+		fmt.Println(err)
+		return err
+	}
+
 	// perform the action
 	users, err := cluster.GetUsersForTenant(appCtx, int32(offset), int32(limit))
 	if err != nil {


### PR DESCRIPTION
**Big change, need a lot of eyes**

With the current approach to managing database connections we are opening a db connection per tenant, this means that at any given point if we have `n` tenants we have `1+n` connections on any instance of m3 (m3, scheduler or a task) this quickly overruns the max number of connections supported by a regular postgres (100 on a 4GB ram instance)

To fix this we are moving to a connection model, similar to Django, where all the operations always happen within  a transaction, and the transaction is started at the begining of the request, since we already have the `cluster.Context` and we already keep transactions there, I just moved all non-transacitonal queries to use ctx transactions.

More over, the transactions are started when the context is started.

`db.GetInstance().Db` is deprecated and should be avoided