### PR TITLE
increase the size of servername hash on nginx config

### DIFF
--- a/cluster/nginx.go
+++ b/cluster/nginx.go
@@ -365,6 +365,7 @@ func getGlobalBucketNamespaceConfiguration(ctx *Context) string {
 
 	nginxConfiguration.WriteString(fmt.Sprintf(`
 			http {
+			server_names_hash_bucket_size  128;
 			upstream portalproxy {
 				server portal-proxy:80;
 			}


### PR DESCRIPTION
To test this.
before the fix:
if you add a bucket name with its max size e.g. `abcdefghijklmnopqrstuvwxyzabcdeabcdefghijklmnopqrstuvwxyzabcdab`
the nginx pod should show an error:
```
2020/01/04 00:16:44 nginx-configuration
2020/01/04 00:16:44 nginx configMap updated: nginx-configuration
2020/01/04 00:16:44 Reloading Nginx
2020/01/04 00:16:44 cmd.Run() failed with %s
 exit status 1
```

delete the nginx pod 
and when restarting the nginx pod should fail like :
```
2020/01/04 00:18:01 Starting ConfigMap Watcher.
2020/01/04 00:18:01 Done Starting nginx
2020/01/04 00:18:01 Start informer
2020/01/04 00:18:01 Starting Nginx
2020/01/04 00:18:01 [emerg] 13#13: could not build server_names_hash, you should increase server_names_hash_bucket_size: 64
nginx: [emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size: 64
2020/01/04 00:18:01 cmd.Run() failed with exit status 1
```

With the new fix we can test the same and the error should not happen and the nginx pod should not fail and run fine.