### PR TITLE
Deprovision of a tenant

### DIFF
--- a/api/stubs/public_api.pb.gw.go
+++ b/api/stubs/public_api.pb.gw.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
@@ -22,11 +23,13 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Suppress "imported and not used" errors
 var _ codes.Code
 var _ io.Reader
 var _ status.Status
 var _ = runtime.String
 var _ = utilities.NewDoubleArray
+var _ = descriptor.ForMessage
 
 func request_PublicAPI_RegisterTenant_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq RegisterAccountRequest
@@ -41,6 +44,23 @@ func request_PublicAPI_RegisterTenant_0(ctx context.Context, marshaler runtime.M
 	}
 
 	msg, err := client.RegisterTenant(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_RegisterTenant_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq RegisterAccountRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.RegisterTenant(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -62,6 +82,23 @@ func request_PublicAPI_Login_0(ctx context.Context, marshaler runtime.Marshaler,
 
 }
 
+func local_request_PublicAPI_Login_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq LoginRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.Login(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_Logout_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq Empty
 	var metadata runtime.ServerMetadata
@@ -75,6 +112,23 @@ func request_PublicAPI_Logout_0(ctx context.Context, marshaler runtime.Marshaler
 	}
 
 	msg, err := client.Logout(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_Logout_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq Empty
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.Logout(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -96,6 +150,23 @@ func request_PublicAPI_SetPassword_0(ctx context.Context, marshaler runtime.Mars
 
 }
 
+func local_request_PublicAPI_SetPassword_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq SetPasswordRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.SetPassword(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_ChangePassword_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ChangePasswordRequest
 	var metadata runtime.ServerMetadata
@@ -109,6 +180,23 @@ func request_PublicAPI_ChangePassword_0(ctx context.Context, marshaler runtime.M
 	}
 
 	msg, err := client.ChangePassword(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_ChangePassword_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ChangePasswordRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ChangePassword(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -130,6 +218,23 @@ func request_PublicAPI_UserAddInvite_0(ctx context.Context, marshaler runtime.Ma
 
 }
 
+func local_request_PublicAPI_UserAddInvite_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq InviteRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.UserAddInvite(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_UserResetPasswordInvite_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq InviteRequest
 	var metadata runtime.ServerMetadata
@@ -143,6 +248,23 @@ func request_PublicAPI_UserResetPasswordInvite_0(ctx context.Context, marshaler 
 	}
 
 	msg, err := client.UserResetPasswordInvite(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_UserResetPasswordInvite_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq InviteRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.UserResetPasswordInvite(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -164,6 +286,23 @@ func request_PublicAPI_ValidateInvite_0(ctx context.Context, marshaler runtime.M
 
 }
 
+func local_request_PublicAPI_ValidateInvite_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ValidateInviteRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ValidateInvite(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 var (
 	filter_PublicAPI_Metrics_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 )
@@ -172,11 +311,27 @@ func request_PublicAPI_Metrics_0(ctx context.Context, marshaler runtime.Marshale
 	var protoReq MetricsRequest
 	var metadata runtime.ServerMetadata
 
-	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_Metrics_0); err != nil {
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_PublicAPI_Metrics_0); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.Metrics(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_Metrics_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq MetricsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_Metrics_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.Metrics(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -189,11 +344,27 @@ func request_PublicAPI_ListBuckets_0(ctx context.Context, marshaler runtime.Mars
 	var protoReq ListBucketsRequest
 	var metadata runtime.ServerMetadata
 
-	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_ListBuckets_0); err != nil {
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_PublicAPI_ListBuckets_0); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.ListBuckets(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_ListBuckets_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListBucketsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_ListBuckets_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ListBuckets(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -211,6 +382,23 @@ func request_PublicAPI_MakeBucket_0(ctx context.Context, marshaler runtime.Marsh
 	}
 
 	msg, err := client.MakeBucket(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_MakeBucket_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq MakeBucketRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.MakeBucket(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -238,6 +426,33 @@ func request_PublicAPI_DeleteBucket_0(ctx context.Context, marshaler runtime.Mar
 	}
 
 	msg, err := client.DeleteBucket(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_DeleteBucket_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq DeleteBucketRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+
+	protoReq.Name, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+
+	msg, err := server.DeleteBucket(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -277,11 +492,55 @@ func request_PublicAPI_ChangeBucketAccessControl_0(ctx context.Context, marshale
 
 }
 
+func local_request_PublicAPI_ChangeBucketAccessControl_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq AccessControlRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+
+	protoReq.Name, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+
+	msg, err := server.ChangeBucketAccessControl(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_UserWhoAmI_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq Empty
 	var metadata runtime.ServerMetadata
 
 	msg, err := client.UserWhoAmI(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_UserWhoAmI_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq Empty
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.UserWhoAmI(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -294,11 +553,27 @@ func request_PublicAPI_ListUsers_0(ctx context.Context, marshaler runtime.Marsha
 	var protoReq ListUsersRequest
 	var metadata runtime.ServerMetadata
 
-	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_ListUsers_0); err != nil {
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_PublicAPI_ListUsers_0); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.ListUsers(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_ListUsers_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListUsersRequest
+	var metadata runtime.ServerMetadata
+
+	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_ListUsers_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ListUsers(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -316,6 +591,23 @@ func request_PublicAPI_AddUser_0(ctx context.Context, marshaler runtime.Marshale
 	}
 
 	msg, err := client.AddUser(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_AddUser_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq AddUserRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.AddUser(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -355,6 +647,41 @@ func request_PublicAPI_DisableUser_0(ctx context.Context, marshaler runtime.Mars
 
 }
 
+func local_request_PublicAPI_DisableUser_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UserActionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.DisableUser(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_ForgotPassword_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ForgotPasswordRequest
 	var metadata runtime.ServerMetadata
@@ -368,6 +695,23 @@ func request_PublicAPI_ForgotPassword_0(ctx context.Context, marshaler runtime.M
 	}
 
 	msg, err := client.ForgotPassword(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_ForgotPassword_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ForgotPasswordRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ForgotPassword(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -407,6 +751,41 @@ func request_PublicAPI_EnableUser_0(ctx context.Context, marshaler runtime.Marsh
 
 }
 
+func local_request_PublicAPI_EnableUser_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UserActionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.EnableUser(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_RemoveUser_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq UserActionRequest
 	var metadata runtime.ServerMetadata
@@ -430,6 +809,33 @@ func request_PublicAPI_RemoveUser_0(ctx context.Context, marshaler runtime.Marsh
 	}
 
 	msg, err := client.RemoveUser(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_RemoveUser_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UserActionRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.RemoveUser(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -461,6 +867,33 @@ func request_PublicAPI_InfoUser_0(ctx context.Context, marshaler runtime.Marshal
 
 }
 
+func local_request_PublicAPI_InfoUser_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UserActionRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.InfoUser(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 var (
 	filter_PublicAPI_ListServiceAccounts_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 )
@@ -469,11 +902,27 @@ func request_PublicAPI_ListServiceAccounts_0(ctx context.Context, marshaler runt
 	var protoReq ListServiceAccountsRequest
 	var metadata runtime.ServerMetadata
 
-	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_ListServiceAccounts_0); err != nil {
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_PublicAPI_ListServiceAccounts_0); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.ListServiceAccounts(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_ListServiceAccounts_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListServiceAccountsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_ListServiceAccounts_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ListServiceAccounts(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -491,6 +940,23 @@ func request_PublicAPI_CreateServiceAccount_0(ctx context.Context, marshaler run
 	}
 
 	msg, err := client.CreateServiceAccount(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_CreateServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq CreateServiceAccountRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.CreateServiceAccount(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -530,6 +996,41 @@ func request_PublicAPI_DisableServiceAccount_0(ctx context.Context, marshaler ru
 
 }
 
+func local_request_PublicAPI_DisableServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ServiceAccountActionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.DisableServiceAccount(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_EnableServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ServiceAccountActionRequest
 	var metadata runtime.ServerMetadata
@@ -565,6 +1066,41 @@ func request_PublicAPI_EnableServiceAccount_0(ctx context.Context, marshaler run
 
 }
 
+func local_request_PublicAPI_EnableServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ServiceAccountActionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.EnableServiceAccount(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_RemoveServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ServiceAccountActionRequest
 	var metadata runtime.ServerMetadata
@@ -592,6 +1128,33 @@ func request_PublicAPI_RemoveServiceAccount_0(ctx context.Context, marshaler run
 
 }
 
+func local_request_PublicAPI_RemoveServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ServiceAccountActionRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.RemoveServiceAccount(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_InfoServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ServiceAccountActionRequest
 	var metadata runtime.ServerMetadata
@@ -615,6 +1178,33 @@ func request_PublicAPI_InfoServiceAccount_0(ctx context.Context, marshaler runti
 	}
 
 	msg, err := client.InfoServiceAccount(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_InfoServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ServiceAccountActionRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.InfoServiceAccount(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -654,6 +1244,41 @@ func request_PublicAPI_UpdateServiceAccount_0(ctx context.Context, marshaler run
 
 }
 
+func local_request_PublicAPI_UpdateServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UpdateServiceAccountRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.UpdateServiceAccount(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_AssignPermissionsToServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq AddPermissionsSARequest
 	var metadata runtime.ServerMetadata
@@ -689,6 +1314,41 @@ func request_PublicAPI_AssignPermissionsToServiceAccount_0(ctx context.Context, 
 
 }
 
+func local_request_PublicAPI_AssignPermissionsToServiceAccount_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq AddPermissionsSARequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.AssignPermissionsToServiceAccount(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 var (
 	filter_PublicAPI_ListPermissions_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 )
@@ -697,11 +1357,27 @@ func request_PublicAPI_ListPermissions_0(ctx context.Context, marshaler runtime.
 	var protoReq ListPermissionsRequest
 	var metadata runtime.ServerMetadata
 
-	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_ListPermissions_0); err != nil {
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_PublicAPI_ListPermissions_0); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := client.ListPermissions(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_ListPermissions_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListPermissionsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_PublicAPI_ListPermissions_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ListPermissions(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -719,6 +1395,23 @@ func request_PublicAPI_AddPermission_0(ctx context.Context, marshaler runtime.Ma
 	}
 
 	msg, err := client.AddPermission(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_AddPermission_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq AddPermissionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.AddPermission(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -746,6 +1439,33 @@ func request_PublicAPI_RemovePermission_0(ctx context.Context, marshaler runtime
 	}
 
 	msg, err := client.RemovePermission(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_RemovePermission_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq PermissionActionRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.RemovePermission(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -785,6 +1505,41 @@ func request_PublicAPI_UpdatePermission_0(ctx context.Context, marshaler runtime
 
 }
 
+func local_request_PublicAPI_UpdatePermission_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UpdatePermissionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.UpdatePermission(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_PublicAPI_InfoPermission_0(ctx context.Context, marshaler runtime.Marshaler, client PublicAPIClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq PermissionActionRequest
 	var metadata runtime.ServerMetadata
@@ -808,6 +1563,33 @@ func request_PublicAPI_InfoPermission_0(ctx context.Context, marshaler runtime.M
 	}
 
 	msg, err := client.InfoPermission(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_PublicAPI_InfoPermission_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq PermissionActionRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.InfoPermission(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -845,6 +1627,749 @@ func request_PublicAPI_AssignPermissionToMultipleServiceAccounts_0(ctx context.C
 	msg, err := client.AssignPermissionToMultipleServiceAccounts(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
+}
+
+func local_request_PublicAPI_AssignPermissionToMultipleServiceAccounts_0(ctx context.Context, marshaler runtime.Marshaler, server PublicAPIServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq MultiAddPermissionToSAsRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.AssignPermissionToMultipleServiceAccounts(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+// RegisterPublicAPIHandlerServer registers the http handlers for service PublicAPI to "mux".
+// UnaryRPC     :call PublicAPIServer directly.
+// StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+func RegisterPublicAPIHandlerServer(ctx context.Context, mux *runtime.ServeMux, server PublicAPIServer) error {
+
+	mux.Handle("POST", pattern_PublicAPI_RegisterTenant_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_RegisterTenant_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_RegisterTenant_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_Login_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_Login_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_Login_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_Logout_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_Logout_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_Logout_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_SetPassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_SetPassword_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_SetPassword_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("PATCH", pattern_PublicAPI_ChangePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_ChangePassword_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_ChangePassword_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_UserAddInvite_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_UserAddInvite_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_UserAddInvite_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_UserResetPasswordInvite_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_UserResetPasswordInvite_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_UserResetPasswordInvite_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_ValidateInvite_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_ValidateInvite_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_ValidateInvite_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_PublicAPI_Metrics_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_Metrics_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_Metrics_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_PublicAPI_ListBuckets_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_ListBuckets_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_ListBuckets_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_MakeBucket_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_MakeBucket_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_MakeBucket_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("DELETE", pattern_PublicAPI_DeleteBucket_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_DeleteBucket_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_DeleteBucket_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_ChangeBucketAccessControl_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_ChangeBucketAccessControl_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_ChangeBucketAccessControl_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_PublicAPI_UserWhoAmI_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_UserWhoAmI_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_UserWhoAmI_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_PublicAPI_ListUsers_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_ListUsers_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_ListUsers_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_AddUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_AddUser_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_AddUser_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_DisableUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_DisableUser_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_DisableUser_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_ForgotPassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_ForgotPassword_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_ForgotPassword_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_EnableUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_EnableUser_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_EnableUser_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("DELETE", pattern_PublicAPI_RemoveUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_RemoveUser_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_RemoveUser_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_PublicAPI_InfoUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_InfoUser_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_InfoUser_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_PublicAPI_ListServiceAccounts_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_ListServiceAccounts_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_ListServiceAccounts_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_CreateServiceAccount_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_CreateServiceAccount_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_CreateServiceAccount_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_DisableServiceAccount_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_DisableServiceAccount_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_DisableServiceAccount_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_EnableServiceAccount_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_EnableServiceAccount_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_EnableServiceAccount_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("DELETE", pattern_PublicAPI_RemoveServiceAccount_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_RemoveServiceAccount_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_RemoveServiceAccount_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_PublicAPI_InfoServiceAccount_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_InfoServiceAccount_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_InfoServiceAccount_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("PUT", pattern_PublicAPI_UpdateServiceAccount_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_UpdateServiceAccount_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_UpdateServiceAccount_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_AssignPermissionsToServiceAccount_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_AssignPermissionsToServiceAccount_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_AssignPermissionsToServiceAccount_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_PublicAPI_ListPermissions_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_ListPermissions_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_ListPermissions_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_AddPermission_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_AddPermission_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_AddPermission_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("DELETE", pattern_PublicAPI_RemovePermission_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_RemovePermission_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_RemovePermission_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("PUT", pattern_PublicAPI_UpdatePermission_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_UpdatePermission_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_UpdatePermission_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_PublicAPI_InfoPermission_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_InfoPermission_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_InfoPermission_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_PublicAPI_AssignPermissionToMultipleServiceAccounts_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PublicAPI_AssignPermissionToMultipleServiceAccounts_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_PublicAPI_AssignPermissionToMultipleServiceAccounts_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	return nil
 }
 
 // RegisterPublicAPIHandlerFromEndpoint is same as RegisterPublicAPIHandler but
@@ -1589,75 +3114,75 @@ func RegisterPublicAPIHandlerClient(ctx context.Context, mux *runtime.ServeMux, 
 }
 
 var (
-	pattern_PublicAPI_RegisterTenant_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "accounts", "signup"}, ""))
+	pattern_PublicAPI_RegisterTenant_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "accounts", "signup"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_Login_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "login"}, ""))
+	pattern_PublicAPI_Login_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "login"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_Logout_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "logout"}, ""))
+	pattern_PublicAPI_Logout_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "logout"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_SetPassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "set_password"}, ""))
+	pattern_PublicAPI_SetPassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "set_password"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_ChangePassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "change_password"}, ""))
+	pattern_PublicAPI_ChangePassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "change_password"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_UserAddInvite_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "add_invite"}, ""))
+	pattern_PublicAPI_UserAddInvite_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "add_invite"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_UserResetPasswordInvite_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "reset_invite"}, ""))
+	pattern_PublicAPI_UserResetPasswordInvite_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "reset_invite"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_ValidateInvite_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "validate_invite"}, ""))
+	pattern_PublicAPI_ValidateInvite_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "validate_invite"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_Metrics_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "metrics"}, ""))
+	pattern_PublicAPI_Metrics_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "metrics"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_ListBuckets_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "buckets"}, ""))
+	pattern_PublicAPI_ListBuckets_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "buckets"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_MakeBucket_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "buckets"}, ""))
+	pattern_PublicAPI_MakeBucket_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "buckets"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_DeleteBucket_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "buckets", "name"}, ""))
+	pattern_PublicAPI_DeleteBucket_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "buckets", "name"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_ChangeBucketAccessControl_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "buckets", "name", "access_control"}, ""))
+	pattern_PublicAPI_ChangeBucketAccessControl_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "buckets", "name", "access_control"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_UserWhoAmI_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "whoami"}, ""))
+	pattern_PublicAPI_UserWhoAmI_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "whoami"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_ListUsers_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "users"}, ""))
+	pattern_PublicAPI_ListUsers_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "users"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_AddUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "users"}, ""))
+	pattern_PublicAPI_AddUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "users"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_DisableUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "users", "id", "disable"}, ""))
+	pattern_PublicAPI_DisableUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "users", "id", "disable"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_ForgotPassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "forgot_password"}, ""))
+	pattern_PublicAPI_ForgotPassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "users", "forgot_password"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_EnableUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "users", "id", "enable"}, ""))
+	pattern_PublicAPI_EnableUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "users", "id", "enable"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_RemoveUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "users", "id"}, ""))
+	pattern_PublicAPI_RemoveUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "users", "id"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_InfoUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "users", "id"}, ""))
+	pattern_PublicAPI_InfoUser_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "users", "id"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_ListServiceAccounts_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "service_accounts"}, ""))
+	pattern_PublicAPI_ListServiceAccounts_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "service_accounts"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_CreateServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "service_accounts"}, ""))
+	pattern_PublicAPI_CreateServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "service_accounts"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_DisableServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "service_accounts", "id", "disable"}, ""))
+	pattern_PublicAPI_DisableServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "service_accounts", "id", "disable"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_EnableServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "service_accounts", "id", "enable"}, ""))
+	pattern_PublicAPI_EnableServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "service_accounts", "id", "enable"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_RemoveServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "service_accounts", "id"}, ""))
+	pattern_PublicAPI_RemoveServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "service_accounts", "id"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_InfoServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "service_accounts", "id"}, ""))
+	pattern_PublicAPI_InfoServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "service_accounts", "id"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_UpdateServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "service_accounts", "id"}, ""))
+	pattern_PublicAPI_UpdateServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "service_accounts", "id"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_AssignPermissionsToServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "service_accounts", "id", "assign_permissions"}, ""))
+	pattern_PublicAPI_AssignPermissionsToServiceAccount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "service_accounts", "id", "assign_permissions"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_ListPermissions_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "permissions"}, ""))
+	pattern_PublicAPI_ListPermissions_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "permissions"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_AddPermission_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "permissions"}, ""))
+	pattern_PublicAPI_AddPermission_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "permissions"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_RemovePermission_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "permissions", "id"}, ""))
+	pattern_PublicAPI_RemovePermission_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "permissions", "id"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_UpdatePermission_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "permissions", "id"}, ""))
+	pattern_PublicAPI_UpdatePermission_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "permissions", "id"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_InfoPermission_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "permissions", "id"}, ""))
+	pattern_PublicAPI_InfoPermission_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "permissions", "id"}, "", runtime.AssumeColonVerbOpt(true)))
 
-	pattern_PublicAPI_AssignPermissionToMultipleServiceAccounts_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "permissions", "id", "assign_to_service_accounts"}, ""))
+	pattern_PublicAPI_AssignPermissionToMultipleServiceAccounts_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "permissions", "id", "assign_to_service_accounts"}, "", runtime.AssumeColonVerbOpt(true)))
 )
 
 var (

--- a/cluster/buckets.go
+++ b/cluster/buckets.go
@@ -175,32 +175,6 @@ func ListBuckets(tenantShortname string) ([]TenantBucketInfo, error) {
 	return bucketInfos, nil
 }
 
-// DeleteAllBuckets gets all buckets and deletes them one by one for a particular tenant
-func DeleteAllBuckets(tenantDomain string) error {
-	// Get tenant specific MinIO client
-	minioClient, err := newTenantMinioClient(nil, tenantDomain)
-	if err != nil {
-		return err
-	}
-
-	tCtx, cancel := context.WithTimeout(context.Background(), time.Second*20)
-	defer cancel()
-
-	var buckets []minio.BucketInfo
-	buckets, err = minioClient.ListBucketsWithContext(tCtx)
-	if err != nil {
-		return tagErrorAsMinio("ListBucketsWithContext", err)
-	}
-
-	for _, bucket := range buckets {
-		err = minioClient.RemoveBucket(bucket.Name)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // Deletes a bucket in the given tenant's MinIO
 func DeleteBucket(tenantShortname, bucket string) error {
 	// Get tenant specific MinIO client

--- a/cluster/buckets.go
+++ b/cluster/buckets.go
@@ -175,6 +175,32 @@ func ListBuckets(tenantShortname string) ([]TenantBucketInfo, error) {
 	return bucketInfos, nil
 }
 
+// DeleteAllBuckets gets all buckets and deletes them one by one for a particular tenant
+func DeleteAllBuckets(tenantDomain string) error {
+	// Get tenant specific MinIO client
+	minioClient, err := newTenantMinioClient(nil, tenantDomain)
+	if err != nil {
+		return err
+	}
+
+	tCtx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	defer cancel()
+
+	var buckets []minio.BucketInfo
+	buckets, err = minioClient.ListBucketsWithContext(tCtx)
+	if err != nil {
+		return tagErrorAsMinio("ListBucketsWithContext", err)
+	}
+
+	for _, bucket := range buckets {
+		err = minioClient.RemoveBucket(bucket.Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Deletes a bucket in the given tenant's MinIO
 func DeleteBucket(tenantShortname, bucket string) error {
 	// Get tenant specific MinIO client

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -290,25 +290,14 @@ func CreateDeploymentWithTenants(tenants []*StorageGroupTenant, sg *StorageGroup
 }
 
 // DeprovisionTenantOnStorageGroup deletes the tenant from the storage group and deletes all tenant's data from disks
-func DeprovisionTenantOnStorageGroup(ctx *Context, tenant *Tenant, sg *StorageGroup) chan error {
+func DeprovisionTenantOnStorageGroup(ctx *Context, sgt *StorageGroupTenantResult) chan error {
 	ch := make(chan error)
 	go func() {
 		defer close(ch)
-		if tenant == nil || sg == nil {
-			ch <- errors.New("nil Tenant or StorageGroup passed")
-			return
-		}
-
-		sgTenantResult := <-GetTenantStorageGroupByShortName(ctx, tenant.ShortName)
-		if sgTenantResult.Error != nil {
-			ch <- sgTenantResult.Error
-			return
-		}
-
 		// start the jobs that create the tenant folder on each disk on each node of the storage group
 		var jobChs []chan error
 		// get a list of nodes on the cluster
-		nodes, err := GetNodesForStorageGroup(ctx, &sg.ID)
+		nodes, err := GetNodesForStorageGroup(ctx, &sgt.StorageGroupTenant.StorageGroup.ID)
 		if err != nil {
 			ch <- err
 			return
@@ -317,8 +306,9 @@ func DeprovisionTenantOnStorageGroup(ctx *Context, tenant *Tenant, sg *StorageGr
 			ch <- errors.New("Nodes not found to deprovision the tenant")
 			return
 		}
+
 		for _, sgNode := range nodes {
-			jobCh := DeleteTenantFolderInDisk(tenant, sg, sgNode)
+			jobCh := RecreateTenantFolderInDisk(sgt.StorageGroupTenant.Tenant, sgt.StorageGroupTenant.StorageGroup, sgNode)
 			jobChs = append(jobChs, jobCh)
 		}
 		// wait for all the jobs to complete
@@ -328,27 +318,6 @@ func DeprovisionTenantOnStorageGroup(ctx *Context, tenant *Tenant, sg *StorageGr
 				ch <- err
 				return
 			}
-		}
-
-		//delete service
-		err = <-DeleteTenantServiceInStorageGroup(sgTenantResult.StorageGroupTenant)
-		if err != nil {
-			ch <- err
-			return
-		}
-
-		// delete database records
-		err = <-DeleteTenantRecord(ctx, tenant.ShortName)
-		if err != nil {
-			ch <- err
-			return
-		}
-
-		// call for the storage group to refresh
-		err = <-ReDeployStorageGroup(ctx, sg)
-		if err != nil {
-			ch <- err
-			return
 		}
 
 	}()
@@ -417,8 +386,8 @@ func ProvisionTenantOnStorageGroup(ctx *Context, tenant *Tenant, sg *StorageGrou
 	return ch
 }
 
-// DeleteTenantFolderInDisk Deletes the tenant folder in disk, this will delete all tenant's related data
-func DeleteTenantFolderInDisk(tenant *Tenant, sg *StorageGroup, sgNode *StorageGroupNode) chan error {
+// RecreateTenantFolderInDisk deletes the tenant folder in disk and recreates it
+func RecreateTenantFolderInDisk(tenant *Tenant, sg *StorageGroup, sgNode *StorageGroupNode) chan error {
 	ch := make(chan error)
 	go func() {
 		defer close(ch)
@@ -482,7 +451,7 @@ func DeleteTenantFolderInDisk(tenant *Tenant, sg *StorageGroup, sgNode *StorageG
 
 			newFolderForDeletion := fmt.Sprintf("%s/%s-to-delete-%s", vol.MountPath, tenant.ShortName, randSringForDeletion)
 			// move current tenant path for one to be deleted and delete if afterwards
-			commands = append(commands, fmt.Sprintf(`mv -v %s/%s %s && rm -rv %s`, vol.MountPath, tenant.ShortName, newFolderForDeletion, newFolderForDeletion))
+			commands = append(commands, fmt.Sprintf(`mv -v %s/%s %s && rm -rv %s && mkdir -p %s/%s`, vol.MountPath, tenant.ShortName, newFolderForDeletion, newFolderForDeletion, vol.MountPath, tenant.ShortName))
 			mount := v1.VolumeMount{
 				Name:      vName,
 				MountPath: vol.MountPath,
@@ -494,19 +463,19 @@ func DeleteTenantFolderInDisk(tenant *Tenant, sg *StorageGroup, sgNode *StorageG
 		jobContainer.VolumeMounts = volumeMounts
 		job.Spec.Template.Spec.Containers = append(job.Spec.Template.Spec.Containers, jobContainer)
 
-		_, err = clientset.BatchV1().Jobs("default").Create(&job)
+		_, err = clientset.BatchV1().Jobs(provisioningNamespace).Create(&job)
 		if err != nil {
 			ch <- err
 			return
 		}
 		//now sit and wait for the job to complete before returning
 		for {
-			status, err := clientset.BatchV1().Jobs("default").Get(jobName, metav1.GetOptions{})
+			status, err := clientset.BatchV1().Jobs(provisioningNamespace).Get(jobName, metav1.GetOptions{})
 			if err != nil {
 				panic(err)
 			}
 			// if completitions above 1 job is complete
-			if *status.Spec.Completions > 0 {
+			if status.Status.Succeeded > 0 {
 				// we are done here
 				//return
 				break
@@ -514,7 +483,7 @@ func DeleteTenantFolderInDisk(tenant *Tenant, sg *StorageGroup, sgNode *StorageG
 			time.Sleep(300 * time.Millisecond)
 		}
 		// job cleanup
-		err = clientset.BatchV1().Jobs("default").Delete(jobName, nil)
+		err = clientset.BatchV1().Jobs(provisioningNamespace).Delete(jobName, nil)
 		if err != nil {
 			ch <- err
 			return

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -39,21 +39,6 @@ func addMinioUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, acce
 	return nil
 }
 
-func deleteMinioUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string) error {
-	// get an admin with operator keys
-	adminClient, pErr := NewAdminClient(sgt.HTTPAddress(false), tenantConf.AccessKey, tenantConf.SecretKey)
-	if pErr != nil {
-		return pErr.Cause
-	}
-	// Add the user
-	err := adminClient.RemoveUser(accessKey)
-	if err != nil {
-		log.Println(err)
-		return tagErrorAsMinio("DeleteUser", err)
-	}
-	return nil
-}
-
 func addMinioCannedPolicyToUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string, policy string) error {
 	// get an admin with operator keys
 	adminClient, pErr := NewAdminClient(sgt.HTTPAddress(false), tenantConf.AccessKey, tenantConf.SecretKey)
@@ -85,20 +70,6 @@ func addMinioIAMPolicyToUser(sgt *StorageGroupTenant, tenantConf *TenantConfigur
 	err = adminClient.SetPolicy(policyName, userAccessKey, false)
 	if err != nil {
 		return tagErrorAsMinio("SetPolicy", err)
-	}
-	return nil
-}
-
-func deleteMinioPolicy(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, policyName string) error {
-	// get an admin with operator keys
-	adminClient, pErr := NewAdminClient(sgt.HTTPAddress(false), tenantConf.AccessKey, tenantConf.SecretKey)
-	if pErr != nil {
-		return pErr.Cause
-	}
-	// Add the canned policy
-	err := adminClient.RemoveCannedPolicy(policyName)
-	if err != nil {
-		return tagErrorAsMinio("RemoveCannedPolicy", err)
 	}
 	return nil
 }

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -116,7 +116,7 @@ func stopMinioTenantServers(sgt *StorageGroupTenant, tenantConf *TenantConfigura
 	if pErr != nil {
 		return pErr.Cause
 	}
-	// Restart minios after setting configuration
+	// Stop MinIO servers
 	err := adminClient.ServiceStop()
 	if err != nil {
 		return tagErrorAsMinio("ServiceStop", err)
@@ -129,7 +129,7 @@ func restartMinioTenantServers(sgt *StorageGroupTenant, tenantConf *TenantConfig
 	if pErr != nil {
 		return pErr.Cause
 	}
-	// Restart minios after setting configuration
+	// Restart MinIO servers
 	err := adminClient.ServiceRestart()
 	if err != nil {
 		return tagErrorAsMinio("ServiceRestart", err)

--- a/cluster/minio.go
+++ b/cluster/minio.go
@@ -39,6 +39,21 @@ func addMinioUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, acce
 	return nil
 }
 
+func deleteMinioUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string) error {
+	// get an admin with operator keys
+	adminClient, pErr := NewAdminClient(sgt.HTTPAddress(false), tenantConf.AccessKey, tenantConf.SecretKey)
+	if pErr != nil {
+		return pErr.Cause
+	}
+	// Add the user
+	err := adminClient.RemoveUser(accessKey)
+	if err != nil {
+		log.Println(err)
+		return tagErrorAsMinio("DeleteUser", err)
+	}
+	return nil
+}
+
 func addMinioCannedPolicyToUser(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, accessKey string, policy string) error {
 	// get an admin with operator keys
 	adminClient, pErr := NewAdminClient(sgt.HTTPAddress(false), tenantConf.AccessKey, tenantConf.SecretKey)
@@ -70,6 +85,20 @@ func addMinioIAMPolicyToUser(sgt *StorageGroupTenant, tenantConf *TenantConfigur
 	err = adminClient.SetPolicy(policyName, userAccessKey, false)
 	if err != nil {
 		return tagErrorAsMinio("SetPolicy", err)
+	}
+	return nil
+}
+
+func deleteMinioPolicy(sgt *StorageGroupTenant, tenantConf *TenantConfiguration, policyName string) error {
+	// get an admin with operator keys
+	adminClient, pErr := NewAdminClient(sgt.HTTPAddress(false), tenantConf.AccessKey, tenantConf.SecretKey)
+	if pErr != nil {
+		return pErr.Cause
+	}
+	// Add the canned policy
+	err := adminClient.RemoveCannedPolicy(policyName)
+	if err != nil {
+		return tagErrorAsMinio("RemoveCannedPolicy", err)
 	}
 	return nil
 }
@@ -120,6 +149,19 @@ func stopMinioTenantServers(sgt *StorageGroupTenant, tenantConf *TenantConfigura
 	err := adminClient.ServiceStop()
 	if err != nil {
 		return tagErrorAsMinio("ServiceStop", err)
+	}
+	return nil
+}
+
+func restartMinioTenantServers(sgt *StorageGroupTenant, tenantConf *TenantConfiguration) error {
+	adminClient, pErr := NewAdminClient(sgt.HTTPAddress(false), tenantConf.AccessKey, tenantConf.SecretKey)
+	if pErr != nil {
+		return pErr.Cause
+	}
+	// Restart minios after setting configuration
+	err := adminClient.ServiceRestart()
+	if err != nil {
+		return tagErrorAsMinio("ServiceRestart", err)
 	}
 	return nil
 }

--- a/cluster/scheduler.go
+++ b/cluster/scheduler.go
@@ -47,8 +47,9 @@ const (
 	failTask              = "fail"
 	emptyTask             = "empty"
 	TaskProvisionTenant   = "provision-tenant"
-	TaskInviteUserByEmail = "invite-user-by-email"
-	TaskSendAdminInvite   = "send-admin-invite"
+	TaskDeprovisionTenant = "deprovision-tenant"
+    TaskInviteUserByEmail = "invite-user-by-email"
+    TaskSendAdminInvite   = "send-admin-invite"
 )
 
 type Task struct {
@@ -257,14 +258,18 @@ func RunTask(id int64) error {
 		if err := ProvisionTenantTask(task); err != nil {
 			panic(err)
 		}
-	case TaskInviteUserByEmail:
-		if err := InviteUserByEmailTask(task); err != nil {
+	case TaskDeprovisionTenant:
+		if err := DeprovisionTenantTask(task); err != nil {
 			panic(err)
 		}
-	case TaskSendAdminInvite:
-		if err := SendAdminInviteTask(task); err != nil {
-			panic(err)
-		}
+    case TaskInviteUserByEmail:
+        if err := InviteUserByEmailTask(task); err != nil {
+            panic(err)
+        }
+    case TaskSendAdminInvite:
+        if err := SendAdminInviteTask(task); err != nil {
+            panic(err)
+        }
 	default:
 		log.Printf("Unknown task name: %s\n", task.Name)
 		if err := markTask(ctx, task, UnknownTaskStatus); err != nil {

--- a/cluster/scheduler.go
+++ b/cluster/scheduler.go
@@ -48,8 +48,8 @@ const (
 	emptyTask             = "empty"
 	TaskProvisionTenant   = "provision-tenant"
 	TaskDeprovisionTenant = "deprovision-tenant"
-    TaskInviteUserByEmail = "invite-user-by-email"
-    TaskSendAdminInvite   = "send-admin-invite"
+	TaskInviteUserByEmail = "invite-user-by-email"
+	TaskSendAdminInvite   = "send-admin-invite"
 )
 
 type Task struct {
@@ -262,14 +262,14 @@ func RunTask(id int64) error {
 		if err := DeprovisionTenantTask(task); err != nil {
 			panic(err)
 		}
-    case TaskInviteUserByEmail:
-        if err := InviteUserByEmailTask(task); err != nil {
-            panic(err)
-        }
-    case TaskSendAdminInvite:
-        if err := SendAdminInviteTask(task); err != nil {
-            panic(err)
-        }
+	case TaskInviteUserByEmail:
+		if err := InviteUserByEmailTask(task); err != nil {
+			panic(err)
+		}
+	case TaskSendAdminInvite:
+		if err := SendAdminInviteTask(task); err != nil {
+			panic(err)
+		}
 	default:
 		log.Printf("Unknown task name: %s\n", task.Name)
 		if err := markTask(ctx, task, UnknownTaskStatus); err != nil {

--- a/cluster/tenants.go
+++ b/cluster/tenants.go
@@ -27,6 +27,7 @@ import (
 	"github.com/minio/m3/cluster/db"
 
 	"github.com/golang-migrate/migrate/v4"
+	pb "github.com/minio/m3/api/stubs"
 	"github.com/minio/minio-go/v6"
 	uuid "github.com/satori/go.uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +51,10 @@ type AddTenantResult struct {
 type ProvisionTenantTaskData struct {
 	Tenants        []string
 	StorageGroupID uuid.UUID
+}
+
+type DeprovisionTenantTaskData struct {
+	TenantID *uuid.UUID
 }
 
 const (
@@ -123,70 +128,106 @@ func ProvisionTenants(ctx *Context, tenants []string, sg *StorageGroup) error {
 	return nil
 }
 
+type TenantAddActionResult struct {
+	TenantResponse *pb.TenantResponse
+	Error          error
+}
+
 // TenantAddAction adds a tenant to the cluster, if an admin name and email are provided, the user is created and invited
 // via email.
-func TenantAddAction(ctx *Context, name, domain, userName, userEmail string) error {
-	// check if tenant name is available
-	available, err := TenantShortNameAvailable(ctx, domain)
-	if err != nil {
-		log.Println(err)
-		return errors.New("Error validating domain")
-	}
-	if !available {
-		return errors.New("Error tenant's shortname not available")
-	}
+func TenantAddAction(ctx *Context, name, domain, userName, userEmail string) chan TenantAddActionResult {
+	ch := make(chan TenantAddActionResult, 10)
+	go func() {
+		defer close(ch)
+		// check if tenant name is available
+		ch <- TenantAddActionResult{TenantResponse: ProgressStruct(10, "validating tenant")}
 
-	// Find an available tenant
-	tenant, err := GrabAvailableTenant(ctx)
-	if err != nil {
-		return errors.New("No space available")
-	}
-	// now that we have a tenant, designate it as the tenant to be used in context
-	ctx.Tenant = tenant
-	if err = ClaimTenant(ctx, tenant, name, domain); err != nil {
-		return err
-	}
-	// update the context tenant
-	ctx.Tenant.Name = name
-	ctx.Tenant.Domain = domain
-	sgt := <-GetTenantStorageGroupByShortName(ctx, tenant.ShortName)
-	if sgt.Error != nil {
-		return sgt.Error
-	}
-
-	// announce the tenant on the router
-	nginxCh := UpdateNginxConfiguration(ctx)
-	// check if we were able to provision the schema and be done running the migrations
-
-	// wait for router
-	err = <-nginxCh
-	if err != nil {
-		log.Println("Error updating nginx configuration: ", err)
-		return errors.New("Error updating nginx configuration")
-	}
-
-	// if the first admin name and email was provided send them an invitation
-	if userName != "" && userEmail != "" {
-		// wait for MinIO to be ready before creating the first user
-		ready := IsMinioReadyRetry(ctx)
-		if !ready {
-			return errors.New("MinIO was never ready. Unable to complete configuration of tenant")
-		}
-		// insert user to DB with random password
-		newUser := User{Name: userName, Email: userEmail}
-		err := AddUser(ctx, &newUser)
+		available, err := TenantShortNameAvailable(ctx, domain)
 		if err != nil {
-			log.Println("Error adding first tenant's admin user: ", err)
-			return errors.New("Error adding first tenant's admin user")
+			log.Println(err)
+			ch <- TenantAddActionResult{Error: errors.New("Error validating domain")}
+			return
+
 		}
-		// Invite it's first admin
-		err = InviteUserByEmail(ctx, TokenSignupEmail, &newUser)
+		if !available {
+			ch <- TenantAddActionResult{Error: errors.New("Error tenant's shortname not available")}
+			return
+		}
+
+		// Find an available tenant
+		tenant, err := GrabAvailableTenant(ctx)
 		if err != nil {
-			log.Println("Error inviting user by email: ", err.Error())
-			return errors.New("Error inviting user by email")
+			ch <- TenantAddActionResult{Error: errors.New("No space available")}
+			return
 		}
+		// now that we have a tenant, designate it as the tenant to be used in context
+		ctx.Tenant = tenant
+		if err = ClaimTenant(ctx, tenant, name, domain); err != nil {
+			ch <- TenantAddActionResult{Error: err}
+			return
+		}
+		// update the context tenant
+		ctx.Tenant.Name = name
+		ctx.Tenant.Domain = domain
+		sgt := <-GetTenantStorageGroupByShortName(ctx, tenant.ShortName)
+		if sgt.Error != nil {
+			ch <- TenantAddActionResult{Error: sgt.Error}
+			return
+		}
+		ch <- TenantAddActionResult{TenantResponse: ProgressStruct(40, "updating nginx")}
+
+		// announce the tenant on the router
+		nginxCh := UpdateNginxConfiguration(ctx)
+
+		// wait for router
+		err = <-nginxCh
+		if err != nil {
+			log.Println("Error updating nginx configuration: ", err)
+			ch <- TenantAddActionResult{Error: errors.New("Error updating nginx configuration")}
+			return
+		}
+		ch <- TenantAddActionResult{TenantResponse: ProgressStruct(10, "initializing servers")}
+
+		// if the first admin name and email was provided send them an invitation
+		if userName != "" && userEmail != "" {
+			// wait for MinIO to be ready before creating the first user
+			ready := IsMinioReadyRetry(ctx)
+			if !ready {
+				ch <- TenantAddActionResult{Error: errors.New("MinIO was never ready. Unable to complete configuration of tenant")}
+				return
+			}
+			ch <- TenantAddActionResult{TenantResponse: ProgressStruct(10, "adding first admin user")}
+			// insert user to DB with random password
+			newUser := User{Name: userName, Email: userEmail}
+			err := AddUser(ctx, &newUser)
+			if err != nil {
+				log.Println("Error adding first tenant's admin user: ", err)
+				ch <- TenantAddActionResult{Error: errors.New("Error adding first tenant's admin user")}
+				return
+			}
+			ch <- TenantAddActionResult{TenantResponse: ProgressStruct(10, "inviting user by email")}
+			// Invite it's first admin
+			err = InviteUserByEmail(ctx, TokenSignupEmail, &newUser)
+			if err != nil {
+				log.Println("Error inviting user by email: ", err.Error())
+				ch <- TenantAddActionResult{Error: errors.New("Error inviting user by email")}
+				return
+			}
+			ch <- TenantAddActionResult{TenantResponse: ProgressStruct(10, "done inviting user by email")}
+		} else {
+			ch <- TenantAddActionResult{TenantResponse: ProgressStruct(30, "")}
+		}
+		ch <- TenantAddActionResult{TenantResponse: ProgressStruct(10, "done adding tenant")}
+	}()
+	return ch
+}
+
+func ProgressStruct(progressInt int32, message string) *pb.TenantResponse {
+	progress := &pb.TenantResponse{
+		Progress: progressInt,
+		Message:  fmt.Sprintf(" %s", message),
 	}
-	return err
+	return progress
 }
 
 // Creates a tenant in the DB if tenant short name is unique
@@ -271,7 +312,7 @@ func validTenantShortName(ctx *Context, tenantShortName string) error {
 func CreateTenantSchema(tenantShortName string) error {
 
 	// get the DB connection for the tenant
-	db := db.GetInstance().GetTenantDB(tenantShortName)
+	tenantDB := db.GetInstance().GetTenantDB(tenantShortName)
 
 	// Since we cannot parametrize the tenant name into create schema
 	// we are going to validate the tenant name
@@ -286,21 +327,18 @@ func CreateTenantSchema(tenantShortName string) error {
 	// format in the tenant name assuming it's safe
 	query := fmt.Sprintf(`CREATE SCHEMA "%s"`, tenantShortName)
 
-	_, err = db.Exec(query)
+	_, err = tenantDB.Exec(query)
 	if err != nil {
 		return err
 	}
-	if err = db.Close(); err != nil {
-		return err
-	}
+
 	return nil
 }
 
 // DestroyTenantSchema will drop the tenant schema from the DB.
 func DestroyTenantSchema(tenantName string) error {
-
 	// get the DB connection for the tenant
-	db := db.GetInstance().GetTenantDB(tenantName)
+	tenantDB := db.GetInstance().GetTenantDB(tenantName)
 
 	// Since we cannot parametrize the tenant name into create schema
 	// we are going to validate the tenant name
@@ -315,10 +353,11 @@ func DestroyTenantSchema(tenantName string) error {
 	// format in the tenant name assuming it's safe
 	query := fmt.Sprintf(`DROP SCHEMA %s CASCADE`, tenantName)
 
-	_, err = db.Exec(query)
+	_, err = tenantDB.Exec(query)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -331,11 +370,13 @@ func ProvisionTenantDB(tenantShortName string) chan error {
 		err := CreateTenantSchema(tenantShortName)
 		if err != nil {
 			ch <- err
+			return
 		}
 		// second run the migrations
 		err = <-MigrateTenantDB(tenantShortName)
 		if err != nil {
 			ch <- err
+			return
 		}
 	}()
 	return ch
@@ -349,6 +390,7 @@ func DeleteTenantDB(tenantName string) chan error {
 		err := DestroyTenantSchema(tenantName)
 		if err != nil {
 			ch <- err
+			return
 		}
 	}()
 	return ch
@@ -512,107 +554,102 @@ func GetTenantByDomain(tenantDomain string) (tenant Tenant, err error) {
 	return GetTenantByDomainWithCtx(nil, tenantDomain)
 }
 
-// DeleteTenant runs all the logic to remove a tenant from the cluster.
-// It will delete everything, from schema, to the secrets, all data of that tenant will be lost, except the data on the
-// disk.
-func DeleteTenant(ctx *Context, sgt *StorageGroupTenantResult) error {
-	// StopTenantServers before deprovisioning them.
-	err := StopTenantServers(sgt)
+type TenantDeleteActionResult struct {
+	TenantResponse *pb.TenantResponse
+	Error          error
+}
+
+// ScheduleDeprovisionTenantTask creates a task to be consumed by a kubernetes job
+func ScheduleDeprovisionTenantTask(ctx *Context, tenant *Tenant) chan TenantDeleteActionResult {
+	ch := make(chan TenantDeleteActionResult, 5)
+	go func() {
+		defer close(ch)
+		taskData := DeprovisionTenantTaskData{
+			TenantID: &tenant.ID,
+		}
+		ch <- TenantDeleteActionResult{TenantResponse: ProgressStruct(10, "done scheduling deprovision task")}
+		err := ScheduleTask(ctx, TaskDeprovisionTenant, taskData)
+		if err != nil {
+			log.Printf("WARNING: Could not deprovision tenant: `%s`\n", tenant.Domain)
+		}
+		ch <- TenantDeleteActionResult{TenantResponse: ProgressStruct(80, "done scheduling deprovision task")}
+	}()
+	return ch
+}
+
+// DeprovisionTenantTask runs all the logic to remove a tenant from the cluster.
+//   creates a task for being run inside a kubernetes job which will first move the mount folder to a
+//   provisional folder, then the provisional folder gets deleted and recreated. Once the folders are
+//   recreated the database schema gets deleted and recreated empty. Then we make the service available
+//   for other new tenants and restart MinIO servers so that they initialize in the new empty mount path.
+func DeprovisionTenantTask(task *Task) error {
+	ctx, err := NewEmptyContext()
 	if err != nil {
-		log.Println("Error stopping tenant servers:", err)
-		return errors.New("Error stopping tenant servers")
+		return err
 	}
-	tenantShortName := sgt.StorageGroupTenant.Tenant.ShortName
+	// hydrate the data from the task
+	var taskData DeprovisionTenantTaskData
+	err = json.Unmarshal(task.Data, &taskData)
+	if err != nil {
+		return err
+	}
+	// fetch tenant from db
+	tenant, err := GetTenantByID(taskData.TenantID)
+	ctx.Tenant = &tenant
+
+	sgt := <-GetTenantStorageGroupByShortName(nil, tenant.ShortName)
+	if sgt.Error != nil {
+		return errors.New("storage group not found for tenant")
+	}
+	if sgt.StorageGroupTenant == nil {
+		return errors.New("tenant not found in database")
+	}
+
+	if sgt.StorageGroupTenant.Tenant.Enabled {
+		return errors.New("tenant needs to be disabled for deletion")
+	}
+
 	// Deprovision tenant and delete tenant info from disks
-	err = <-DeprovisionTenantOnStorageGroup(ctx, sgt.Tenant, sgt.StorageGroup)
+	err = <-DeprovisionTenantOnStorageGroup(ctx, sgt)
 	if err != nil {
 		log.Println("Error deprovisioning tenant:", err)
 		return errors.New("Error deprovisioning tenant")
 	}
-
 	// delete tenant schema
 	// wait for schema deletion
-	err = <-DeleteTenantDB(tenantShortName)
+	err = <-DeleteTenantDB(tenant.ShortName)
 	if err != nil {
 		log.Println("Error deleting schema: ", err)
 		return errors.New("Error deleting tenant's")
 	}
-	// purge connection from pool
 
-	db.GetInstance().RemoveCnx(tenantShortName)
-
-	//delete namesapce
-	nsDeleteCh := DeleteTenantNamespace(tenantShortName)
-
-	// announce the tenant on the router
-	nginxCh := UpdateNginxConfiguration(ctx)
-
-	//delete secret
-
-	secretCh := DeleteTenantSecrets(tenantShortName)
-
-	// wait for namespace deletion
-	err = <-nsDeleteCh
+	// provision the tenant schema and run the migrations
+	err = <-ProvisionTenantDB(tenant.ShortName)
+	// wait for db provisioning
 	if err != nil {
-		log.Println("Error deleting namespace: ", err)
-		return errors.New("Error deleting namespace")
+		log.Println("Error creating tenant's db schema: ", err)
+		return errors.New("Error creating tenant's db schema")
 	}
 
-	// wait for secret deletion
-	err = <-secretCh
-	if err != nil {
-		log.Println("Error deleting secret: ", err)
-		return errors.New("Error deleting secret")
+	if err = UnClaimTenant(ctx, sgt.StorageGroupTenant.Tenant); err != nil {
+		log.Println("Error unclaiming tenant:", err)
+		return errors.New("Error unclaiming tenant")
 	}
-	// wait for router
-	err = <-nginxCh
+
+	err = RestartTenantServers(sgt)
+	if err != nil {
+		log.Println("Error restarting tenant servers:", err)
+		return errors.New("Error restarting tenant servers")
+	}
+
+	err = <-UpdateNginxConfiguration(ctx)
 	if err != nil {
 		log.Println("Error updating router: ", err)
-		return errors.New("Error updating router: ")
-	}
-	return err
-}
-
-func DeleteTenantK8sObjects(ctx *Context, tenantShortName string) error {
-	// delete tenant schema
-	// wait for schema deletion
-	err := <-DeleteTenantDB(tenantShortName)
-	if err != nil {
-		log.Println("Error deleting schema: ", err)
-		return errors.New("Error deleting tenant's")
-	}
-	// purge connection from pool
-	db.GetInstance().RemoveCnx(tenantShortName)
-
-	//delete namespace
-	nsDeleteCh := DeleteTenantNamespace(tenantShortName)
-
-	// announce the tenant on the router
-	nginxCh := UpdateNginxConfiguration(ctx)
-
-	//delete secret
-
-	secretCh := DeleteTenantSecrets(tenantShortName)
-
-	// wait for namespace deletion
-	err = <-nsDeleteCh
-	if err != nil {
-		log.Println("Error deleting namespace: ", err)
-		return errors.New("Error deleting namespace")
+		return errors.New("Error updating router")
 	}
 
-	// wait for secret deletion
-	err = <-secretCh
-	if err != nil {
-		log.Println("Error deleting secret: ", err)
-		return errors.New("Error deleting secret")
-	}
-
-	// wait for router
-	err = <-nginxCh
-	if err != nil {
-		log.Println("Error updating router: ", err)
-		return errors.New("Error updating router: ")
+	if err := ctx.Commit(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -753,8 +790,21 @@ func StopTenantServers(sgt *StorageGroupTenantResult) error {
 	if err != nil {
 		return err
 	}
-	// Delete MinIO's user
 	err = stopMinioTenantServers(sgt.StorageGroupTenant, tenantConf)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RestartTenantServers restarts MinIO servers for a particular tenant
+func RestartTenantServers(sgt *StorageGroupTenantResult) error {
+	// Get the credentials for a tenant
+	tenantConf, err := GetTenantConfig(sgt.StorageGroupTenant.Tenant)
+	if err != nil {
+		return err
+	}
+	err = restartMinioTenantServers(sgt.StorageGroupTenant, tenantConf)
 	if err != nil {
 		return err
 	}
@@ -919,6 +969,26 @@ func ClaimTenant(ctx *Context, tenant *Tenant, name, domain string) error {
 		return err
 	}
 	_, err = tx.Exec(query, name, domain, tenant.ID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// UnClaimTenant unclaims a tenant on the database, marks it as  available and disables it for the router
+func UnClaimTenant(ctx *Context, tenant *Tenant) error {
+	// build the query
+	query :=
+		`UPDATE tenants 
+					SET name = $1, domain = $2, available=TRUE, enabled=FALSE
+				WHERE id=$3`
+
+	// Execute Query
+	tx, err := ctx.MainTx()
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(query, tenant.ShortName, tenant.ShortName, tenant.ID)
 	if err != nil {
 		return err
 	}

--- a/cluster/tenants.go
+++ b/cluster/tenants.go
@@ -595,6 +595,10 @@ func DeprovisionTenantTask(task *Task) error {
 	}
 	// fetch tenant from db
 	tenant, err := GetTenantByID(taskData.TenantID)
+	if err != nil {
+		log.Println("Error getting tenant by id:", err)
+		return err
+	}
 	ctx.Tenant = &tenant
 
 	sgt := <-GetTenantStorageGroupByShortName(nil, tenant.ShortName)

--- a/cluster/url-tokens.go
+++ b/cluster/url-tokens.go
@@ -68,15 +68,10 @@ func GetTenantTokenDetails(ctx *Context, urlToken *uuid.UUID) (*URLToken, error)
 				url_tokens
 			WHERE id=$1 LIMIT 1`
 
-	tx, err := ctx.TenantTx()
-	if err != nil {
-		return nil, err
-	}
-
-	row := tx.QueryRow(queryUser, urlToken)
+	row := ctx.TenantDB().QueryRow(queryUser, urlToken)
 
 	// Save the resulted query on the URLToken struct
-	err = row.Scan(&token.ID, &token.UserID, &token.Expiration, &token.UsedFor, &token.Consumed)
+	err := row.Scan(&token.ID, &token.UserID, &token.Expiration, &token.UsedFor, &token.Consumed)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/m3/tenant-add.go
+++ b/cmd/m3/tenant-add.go
@@ -140,5 +140,6 @@ func addTenant(ctx *cli.Context) error {
 		bar.Add(int(resp.Progress))
 		fmt.Print(resp.Message)
 	}
+	fmt.Println()
 	return nil
 }

--- a/cmd/m3/tenant-delete.go
+++ b/cmd/m3/tenant-delete.go
@@ -95,5 +95,6 @@ func tenantDelete(ctx *cli.Context) error {
 		bar.Add(int(resp.Progress))
 		fmt.Print(resp.Message)
 	}
+	fmt.Println()
 	return nil
 }


### PR DESCRIPTION
Removes all tenant's content but keeping the Services so that they can be reused for future tenants.

First it creates a task for being run inside a kubernetes job which will:

1. first move the mount folder to a provisional folder, then the provisional folder gets deleted and recreated. 
2. Once the folders are recreated the database schema gets deleted and recreated empty. 
3. Then we make the service available for other new tenants 
4. Restart MinIO servers so that they initialize in the new empty mount path.

Please take your time to test this.
To test it it is necessary to have a tenant already running then:
Disable Tenant
```
./m3 tenant disable <tenant_domain>
```
Delete Tenant
```
./m3 tenant delete <tenant_domain> --confirm
```