### PR TITLE
fail gracefully during error on service account creation

### DIFF
--- a/cluster/credentials.go
+++ b/cluster/credentials.go
@@ -204,10 +204,15 @@ func GetCredentialsForServiceAccount(ctx *Context, serviceAccountID *uuid.UUID) 
 				LEFT JOIN service_accounts sa ON c.service_account_id = sa.id
 			WHERE sa.id=$1 LIMIT 1`
 
-	row := ctx.TenantDB().QueryRow(queryUser, serviceAccountID)
+	tx, err := ctx.TenantTx()
+	if err != nil {
+		return nil, err
+	}
+
+	row := tx.QueryRow(queryUser, serviceAccountID)
 	sac := ServiceAccountCredentials{}
 	// Save the resulted query on the User struct
-	err := row.Scan(&sac.AccessKey)
+	err = row.Scan(&sac.AccessKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
when an error occurred on service account creation, we were committing the transaction to the db and not rolling it back properly, now that was modified and also we delete the minio user that was created if an error occurs.