### PR TITLE
avoid permissions and service accounts with the same name on creation

### DIFF
--- a/api/api-public-tenant-service-account.go
+++ b/api/api-public-tenant-service-account.go
@@ -54,8 +54,7 @@ func (s *server) CreateServiceAccount(ctx context.Context, in *pb.CreateServiceA
 
 	serviceAccount, saCred, err := cluster.AddServiceAccount(appCtx, appCtx.Tenant.ShortName, name, &name)
 	if err != nil {
-		log.Println(err.Error())
-		return nil, status.New(codes.Internal, "error creating service account").Err()
+		return nil, status.New(codes.Internal, err.Error()).Err()
 	}
 
 	var permissionIDsArr []*uuid.UUID

--- a/cluster/permissions.go
+++ b/cluster/permissions.go
@@ -739,7 +739,7 @@ func getValidPermSlug(ctx *Context, permName string) (*string, error) {
 }
 
 // validatePermissionName verifies that a permission name is valid
-func validatePermissionName(ctx *Context, permissionName string) error {
+func validatePermissionName(ctx *Context, name string) error {
 	query := `
 		SELECT 
 			COUNT(*)
@@ -752,7 +752,7 @@ func validatePermissionName(ctx *Context, permissionName string) error {
 	if err != nil {
 		return err
 	}
-	row := tx.QueryRow(query, permissionName)
+	row := tx.QueryRow(query, name)
 	var count int
 	err = row.Scan(&count)
 	if err != nil {
@@ -760,7 +760,7 @@ func validatePermissionName(ctx *Context, permissionName string) error {
 	}
 	// if count is > 0 it means there is a permission already with that name
 	if count > 0 {
-		return fmt.Errorf("permission name: %s, already exists", permissionName)
+		return fmt.Errorf("permission name: %s, already exists", name)
 	}
 	return nil
 }

--- a/cluster/permissions.go
+++ b/cluster/permissions.go
@@ -205,10 +205,18 @@ func AddPermissionToDB(ctx *Context, name, description string, effect Effect, re
 	if err != nil {
 		return nil, err
 	}
+
+	err = validatePermissionName(ctx, name)
+	if err != nil {
+		log.Println("error validating permission:", err)
+		return nil, fmt.Errorf("permission name: `%s` not valid or already exists", name)
+	}
+
 	permSlug, err := getValidPermSlug(ctx, name)
 	if err != nil {
 		return nil, err
 	}
+
 	perm.Slug = *permSlug
 	// insert to db
 	err = InsertPermission(ctx, perm)
@@ -704,7 +712,7 @@ func GetAllServiceAccountsForPermission(ctx *Context, permissionID *uuid.UUID) (
 func getValidPermSlug(ctx *Context, permName string) (*string, error) {
 	permSlug := slug.Make(permName)
 	// Count the users
-	queryUser := `
+	query := `
 		SELECT 
 			COUNT(*)
 		FROM 
@@ -712,11 +720,13 @@ func getValidPermSlug(ctx *Context, permName string) (*string, error) {
 		WHERE 
 		    slug = $1`
 
-	// TODO: use current transaction to query instead of a connection to the db
-
-	row := ctx.TenantDB().QueryRow(queryUser, permSlug)
+	tx, err := ctx.TenantTx()
+	if err != nil {
+		return nil, err
+	}
+	row := tx.QueryRow(query, permSlug)
 	var count int
-	err := row.Scan(&count)
+	err = row.Scan(&count)
 	if err != nil {
 		return nil, err
 	}
@@ -726,6 +736,33 @@ func getValidPermSlug(ctx *Context, permName string) (*string, error) {
 		permSlug = fmt.Sprintf("%s-%s", permSlug, RandomCharString(4))
 	}
 	return &permSlug, nil
+}
+
+// validatePermissionName verifies that a permission name is valid
+func validatePermissionName(ctx *Context, permissionName string) error {
+	query := `
+		SELECT 
+			COUNT(*)
+		FROM 
+			permissions
+		WHERE 
+		    name = $1`
+
+	tx, err := ctx.TenantTx()
+	if err != nil {
+		return err
+	}
+	row := tx.QueryRow(query, permissionName)
+	var count int
+	err = row.Scan(&count)
+	if err != nil {
+		return err
+	}
+	// if count is > 0 it means there is a permission already with that name
+	if count > 0 {
+		return fmt.Errorf("permission name: %s, already exists", permissionName)
+	}
+	return nil
 }
 
 // GetPermissionBySlug retrieves a permission by it's id-name
@@ -750,7 +787,6 @@ func GetPermissionBySlug(ctx *Context, slug string) (*Permission, error) {
 	if len(perms) > 0 {
 		return perms[0], nil
 	}
-
 	return nil, errors.New("permission not found")
 }
 

--- a/cluster/service-accounts.go
+++ b/cluster/service-accounts.go
@@ -70,10 +70,17 @@ func getValidSASlug(ctx *Context, saName string) (*string, error) {
 // It generates the credentials and store them kon k8s, the returns a complete struct with secret and access key.
 // This is the only time the secret is returned.
 func AddServiceAccount(ctx *Context, tenantShortName string, name string, description *string) (serviceAccount *ServiceAccount, credentials *ServiceAccountCredentials, err error) {
+	err = validateServiceAccountName(ctx, name)
+	if err != nil {
+		log.Println(err)
+		return nil, nil, fmt.Errorf("service account name: `%s` not valid or already exists", name)
+	}
+
 	// generate slug
 	saSlug, err := getValidSASlug(ctx, name)
 	if err != nil {
-		return nil, nil, err
+		log.Println(err)
+		return nil, nil, fmt.Errorf("error creating service account")
 	}
 	serviceAccount = &ServiceAccount{
 		Name:        name,
@@ -89,21 +96,51 @@ func AddServiceAccount(ctx *Context, tenantShortName string, name string, descri
 				($1, $2, $3, $4, $5, $6)`
 	tx, err := ctx.TenantTx()
 	if err != nil {
-		return nil, nil, err
+		log.Println(err)
+		return nil, nil, fmt.Errorf("error creating service account")
 	}
 	// Execute query
 	_, err = tx.Exec(query, serviceAccount.ID, serviceAccount.Name, serviceAccount.Slug, &serviceAccount.Description, serviceAccount.Enabled, ctx.WhoAmI)
 	if err != nil {
-		return nil, nil, err
+		log.Println(err)
+		return nil, nil, fmt.Errorf("error creating service account")
 	}
 
 	// Create this user's credentials so he can interact with it's own buckets/data
 	saCred, err := createServiceAccountCredentials(ctx, tenantShortName, serviceAccount.ID)
 	if err != nil {
-		return nil, nil, err
+		log.Println(err)
+		return nil, nil, fmt.Errorf("error creating service account")
 	}
 	serviceAccount.AccessKey = saCred.AccessKey
 	return serviceAccount, saCred, nil
+}
+
+// validateServiceAccountName verifies that a service account name is valid
+func validateServiceAccountName(ctx *Context, name string) error {
+	query := `
+		SELECT 
+			COUNT(*)
+		FROM 
+			service_accounts
+		WHERE 
+		    name = $1`
+
+	tx, err := ctx.TenantTx()
+	if err != nil {
+		return err
+	}
+	row := tx.QueryRow(query, name)
+	var count int
+	err = row.Scan(&count)
+	if err != nil {
+		return err
+	}
+	// if count is > 0 it means there is a service account already with that name
+	if count > 0 {
+		return fmt.Errorf("service account name: %s, already exists", name)
+	}
+	return nil
 }
 
 // GetServiceAccountList returns a page of services accounts for the provided tenant

--- a/cluster/tenant-migrations/000007_add-unique-index-perm-sa.down.sql
+++ b/cluster/tenant-migrations/000007_add-unique-index-perm-sa.down.sql
@@ -1,0 +1,19 @@
+-- This file is part of MinIO Kubernetes Cloud
+-- Copyright (c) 2019 MinIO, Inc.
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+DROP INDEX IF EXISTS permissions_name_uindex;
+
+DROP INDEX IF EXISTS service_accounts_name_uindex;

--- a/cluster/tenant-migrations/000007_add-unique-index-perm-sa.up.sql
+++ b/cluster/tenant-migrations/000007_add-unique-index-perm-sa.up.sql
@@ -1,0 +1,21 @@
+-- This file is part of MinIO Kubernetes Cloud
+-- Copyright (c) 2019 MinIO, Inc.
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+CREATE UNIQUE INDEX permissions_name_uindex
+    ON permissions (name);
+
+CREATE UNIQUE INDEX service_accounts_name_uindex
+    ON service_accounts (name);


### PR DESCRIPTION
since there might be permissions already on deployments I'm not adding a unique index on the db as a migration since if there are already existing duplicates the migration would fail.