### PR TITLE
add example usage for email-template set command

### DIFF
--- a/cmd/m3/email-template-set.go
+++ b/cmd/m3/email-template-set.go
@@ -38,7 +38,7 @@ var emailSetCmd = cli.Command{
 		cli.StringFlag{
 			Name:  "name",
 			Value: "",
-			Usage: "template name (forgot-password |  invite | new_admin)",
+			Usage: "template name (forgot-password | reset-password |  invite | new_admin)",
 		},
 		cli.StringFlag{
 			Name:  "template",

--- a/cmd/m3/email-template-set.go
+++ b/cmd/m3/email-template-set.go
@@ -27,18 +27,18 @@ import (
 var emailSetCmd = cli.Command{
 	Name: "set",
 	Usage: `Sets an email template on the cluster's database
-	EXAMPLE: 
-		1. Set invite email template from string.
-			m3 email-template set invite "<html><body><p><b>Forgot email body here</b></p></body></html>" 
-		2. Set forgot-password email template from path.
-			m3 email-template set forgot-password "$(< [FILEPATH])
+EXAMPLE: 
+	1. Set invite email template from string.
+		m3 email-template set invite "<html><body><p><b>Forgot email body here</b></p></body></html>" 
+	2. Set forgot-password email template from path.
+		m3 email-template set forgot-password "$(< [FILEPATH])"
 	`,
 	Action: emailTemplateSet,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "name",
 			Value: "",
-			Usage: "template name (forgot-password | reset-password |  invite | new_admin)",
+			Usage: "template name (forgot-password | reset-password | invite | new_admin)",
 		},
 		cli.StringFlag{
 			Name:  "template",

--- a/cmd/m3/email-template-set.go
+++ b/cmd/m3/email-template-set.go
@@ -25,14 +25,20 @@ import (
 
 // sets the template for an email behind an identifier
 var emailSetCmd = cli.Command{
-	Name:   "set",
-	Usage:  "Sets an email template by id",
+	Name: "set",
+	Usage: `Sets an email template on the cluster's database
+	EXAMPLE: 
+		1. Set invite email template from string.
+			m3 email-template set invite "<html><body><p><b>Forgot email body here</b></p></body></html>" 
+		2. Set forgot-password email template from path.
+			m3 email-template set forgot-password "$(< [FILEPATH])
+	`,
 	Action: emailTemplateSet,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "name",
 			Value: "",
-			Usage: "template name",
+			Usage: "template name (forgot-password |  invite | new_admin)",
 		},
 		cli.StringFlag{
 			Name:  "template",


### PR DESCRIPTION
Adding more details on the usage will be shown like :
```
./m3 email-template set --help
NAME:
  m3 email-template set - Sets an email template on the cluster's database
EXAMPLE: 
  1. Set invite email template from string.
    m3 email-template set invite "<html><body><p><b>Forgot email body here</b></p></body></html>" 
  2. Set forgot-password email template from path.
    m3 email-template set forgot-password "$(< [FILEPATH])"
  

USAGE:
  m3 email-template set [command options] [arguments...]

FLAGS:
  --name value      template name (forgot-password | reset-password | invite | new_admin)
  --template value  template body
  --help, -h        show help
```
