### PR TITLE
Adding support for vault client to use custom ca certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ WORKDIR /go/src/github.com/minio/m3/
 ENV CGO_ENABLED=0
 
 RUN apt-get update -y && apt-get install -y ca-certificates
-COPY ca-certificates /usr/local/share/ca-certificates/
-RUN update-ca-certificates
-
 RUN go build -ldflags "-w -s" -a -o m3 ./cmd/m3
 
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -99,6 +99,23 @@ kubectl apply -f k8s/deployments/m3-deployment.yaml
 ./m3 login
 ```
 
+## Using a custom CA for the KMS
+
+Mkube supports the use of custom CA for the kms if need it.
+Load the custom `ca certificate` using a `configmap`
+
+```
+kubectl create configmap kms-ca-cert --from-file=customCA.crt
+```
+
+Then set the `configmap` name and `certificate file name` on `m3-deployment.yaml` by uncommenting the following env variables
+``` 
+KMS_CA_CERT_CONFIG_MAP: "kms-ca-cert"
+KMS_CA_CERT_FILE_NAME: "customCA.crt"
+```
+
+Apply changes for `mkube` running `kubectl apply -f k8s/deployment/m3-deployment.yaml`
+
 ## Creating a new Storage Cluster
 
 ```

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -109,6 +109,10 @@ func getKmsCACertFileName() string {
 	return env.Get(KmsCACertFileName, "")
 }
 
+func getCACertDefaultMounPath() string {
+	return env.Get(CACertDefaultMountPath, "/usr/local/share/ca-certificates")
+}
+
 func getDevUseEmptyDir() bool {
 	return strings.ToLower(env.Get(devUseEmptyDir, "false")) == "true"
 }

--- a/cluster/kes.go
+++ b/cluster/kes.go
@@ -70,7 +70,18 @@ func connectToKms() chan kmsCnxResult {
 			return
 		}
 
-		client, err := vapi.NewClient(&vapi.Config{Address: kmsAddress})
+		config := &vapi.Config{Address: kmsAddress}
+
+		kmsCACertConfigMap := getKmsCACertConfigMap()
+		kmsCACertFileName := getKmsCACertFileName()
+
+		if kmsCACertConfigMap != "" && kmsCACertFileName != "" {
+			config.ConfigureTLS(&vapi.TLSConfig{
+				CACert: fmt.Sprintf("%s/%s", getCACertDefaultMounPath(), kmsCACertFileName),
+			})
+		}
+
+		client, err := vapi.NewClient(config)
 		if err != nil {
 			ch <- kmsCnxResult{Error: err}
 			return

--- a/cluster/scheduler.go
+++ b/cluster/scheduler.go
@@ -208,6 +208,32 @@ func startJob(task *Task) error {
 			},
 		},
 	}
+
+	kmsCACertConfigMap := getKmsCACertConfigMap()
+	kmsCACertFileName := getKmsCACertFileName()
+	//If a CA certificate is present we mount the file
+	if kmsCACertConfigMap != "" && kmsCACertFileName != "" && len(job.Spec.Template.Spec.Containers) > 0 {
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+			{
+				Name:      "kms-ca-volume",
+				MountPath: getCACertDefaultMounPath(),
+				ReadOnly:  true,
+			},
+		}
+		job.Spec.Template.Spec.Volumes = []v1.Volume{
+			{
+				Name: "kms-ca-volume",
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: kmsCACertConfigMap,
+						},
+					},
+				},
+			},
+		}
+	}
+
 	// schedule job in k8s
 	clientset, err := k8sClient()
 	if err != nil {


### PR DESCRIPTION
Mkube supports the use of custom CA for the kms if need it.
Load the custom ca certificate using a configmap: `kubectl create configmap kms-ca-cert --from-file=customCA.crt`
Then set the configmap name and certificate file name on m3-deployment.yaml by uncommenting the following env variables

```
KMS_CA_CERT_CONFIG_MAP: "kms-ca-cert"
KMS_CA_CERT_FILE_NAME: "customCA.crt"
```