### PR TITLE
Only delete a bucket if no permissions are using it

### DIFF
--- a/cluster/tenant-migrations/000008_index-perm-resources.down.sql
+++ b/cluster/tenant-migrations/000008_index-perm-resources.down.sql
@@ -1,0 +1,17 @@
+-- This file is part of MinIO Kubernetes Cloud
+-- Copyright (c) 2019 MinIO, Inc.
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+DROP INDEX IF EXISTS permissions_resources_bucket_name_index;

--- a/cluster/tenant-migrations/000008_index-perm-resources.up.sql
+++ b/cluster/tenant-migrations/000008_index-perm-resources.up.sql
@@ -1,0 +1,18 @@
+-- This file is part of MinIO Kubernetes Cloud
+-- Copyright (c) 2019 MinIO, Inc.
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+CREATE INDEX permissions_resources_bucket_name_index
+    ON permissions_resources (bucket_name);


### PR DESCRIPTION
Since we use postgres db to update permissions I leverage that by filtering permissions where a bucket is being used before deleting a bucket.