### PR TITLE
remove initial get metrics call

### DIFF
--- a/cluster/buckets.go
+++ b/cluster/buckets.go
@@ -755,13 +755,6 @@ func RecurrentTenantMetricsCalculation() chan error {
 	ch := make(chan error)
 	go func() {
 		defer close(ch)
-		// Do at start
-		err := CalculateTenantsMetrics()
-		if err != nil {
-			log.Println(err)
-			ch <- err
-			return
-		}
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
the first call causes a failure on the server if the migrations are not correctly done.