### PR TITLE
Return proper error message if permission name duplicated

### DIFF
--- a/api/api-public-tenant-permissions.go
+++ b/api/api-public-tenant-permissions.go
@@ -100,6 +100,9 @@ func (s *server) AddPermission(ctx context.Context, in *pb.AddPermissionRequest)
 
 	permissionObj, err := cluster.AddPermissionToDB(appCtx, permissionName, description, effect, resources, actions)
 	if err != nil {
+		if err == cluster.ErrPermissionName {
+			return nil, status.New(codes.InvalidArgument, err.Error()).Err()
+		}
 		return nil, status.New(codes.Internal, "There was an error creating the permission").Err()
 	}
 	// if we reach here, all is good, commit


### PR DESCRIPTION
When creating a permission with the same name. Before it was saying `There was an error creating the permission` with no details.
Now it will show. `Permission name not valid or already exists`