### PR TITLE
nginx-user serviceaccount rbac

### DIFF
--- a/k8s/deployments/m3-deployment.yaml.example
+++ b/k8s/deployments/m3-deployment.yaml.example
@@ -33,6 +33,8 @@ rules:
   - ""
   resources:
   - configmaps
+  resourceNames:
+  - nginx-configuration
   verbs:
   - get
   - list


### PR DESCRIPTION
nginx-user serviceaccount limited to only list, get and watch changes on
nginx-configuration the configmap

Testing 
```
$ kubectl auth can-i get configmaps/postgres-env -n default --as=system:serviceaccount:default:nginx-user
no

$ kubectl auth can-i get configmaps/nginx-configuration -n default --as=system:serviceaccount:default:nginx-user
yes
```