### PR TITLE
Rollback rbac changes for nginx-user

### DIFF
--- a/k8s/deployments/m3-deployment.yaml.example
+++ b/k8s/deployments/m3-deployment.yaml.example
@@ -33,8 +33,6 @@ rules:
   - ""
   resources:
   - configmaps
-  resourceNames:
-  - nginx-configuration
   verbs:
   - get
   - list


### PR DESCRIPTION
Rolling back changes for
https://github.com/minio/m3/pull/355 PR
since nginx-user ability to listen for configmap changes (informer) was
broken