### PR TITLE
MCS support arn resource id for event notification configuration

### DIFF
--- a/mcs/models/set_config_request.go
+++ b/mcs/models/set_config_request.go
@@ -36,6 +36,9 @@ import (
 // swagger:model setConfigRequest
 type SetConfigRequest struct {
 
+	// Used if configuration is an event notification's target
+	ArnResourceID string `json:"arn_resource_id,omitempty"`
+
 	// key values
 	// Required: true
 	// Min Items: 1

--- a/mcs/restapi/admin_config_test.go
+++ b/mcs/restapi/admin_config_test.go
@@ -167,7 +167,6 @@ func TestSetConfig(t *testing.T) {
 	assert := assert.New(t)
 	adminClient := adminClientMock{}
 	function := "setConfig()"
-	// Test-1 : setConfig() sets a config with two key value pairs
 	// mock function response from setConfig()
 	minioSetConfigKVMock = func(kv string) error {
 		return nil
@@ -183,7 +182,10 @@ func TestSetConfig(t *testing.T) {
 			Value: "",
 		},
 	}
-	err := setConfig(adminClient, swag.String(configName), kvs)
+	arnResourceID := ""
+
+	// Test-1 : setConfig() sets a config with two key value pairs
+	err := setConfig(adminClient, swag.String(configName), kvs, arnResourceID)
 	if err != nil {
 		t.Errorf("Failed on %s:, error occurred: %s", function, err.Error())
 	}
@@ -192,11 +194,16 @@ func TestSetConfig(t *testing.T) {
 	minioSetConfigKVMock = func(kv string) error {
 		return errors.New("error")
 	}
-	if err := setConfig(adminClient, swag.String(configName), kvs); assert.Error(err) {
+	if err := setConfig(adminClient, swag.String(configName), kvs, arnResourceID); assert.Error(err) {
 		assert.Equal("error", err.Error())
 	}
 
 	// Test-3: buildConfig() format correctly configuration as "config_name k=v k2=v2"
-	config := buildConfig(swag.String(configName), kvs)
+	config := buildConfig(swag.String(configName), kvs, arnResourceID)
 	assert.Equal(fmt.Sprintf("%s enable=off connection_string=", configName), *config)
+
+	// Test-4: buildConfig() format correctly configuration if it has a non empty arnResourceID as "config_name:resourceid k=v k2=v2"
+	arnResourceID = "postgres"
+	config = buildConfig(swag.String(configName), kvs, arnResourceID)
+	assert.Equal(fmt.Sprintf("%s:%s enable=off connection_string=", configName, arnResourceID), *config)
 }

--- a/mcs/restapi/embedded_spec.go
+++ b/mcs/restapi/embedded_spec.go
@@ -913,6 +913,10 @@ func init() {
         "key_values"
       ],
       "properties": {
+        "arn_resource_id": {
+          "type": "string",
+          "title": "Used if configuration is an event notification's target"
+        },
         "key_values": {
           "type": "array",
           "minItems": 1,
@@ -1876,6 +1880,10 @@ func init() {
         "key_values"
       ],
       "properties": {
+        "arn_resource_id": {
+          "type": "string",
+          "title": "Used if configuration is an event notification's target"
+        },
         "key_values": {
           "type": "array",
           "minItems": 1,

--- a/mcs/restapi/server.go
+++ b/mcs/restapi/server.go
@@ -434,7 +434,7 @@ func (s *Server) handleShutdown(wg *sync.WaitGroup, serversPtr *[]*http.Server) 
 
 	servers := *serversPtr
 
-	ctx, cancel := context.WithTimeout(context.Background(), s.GracefulTimeout)
+	ctx, cancel := context.WithTimeout(context.TODO(), s.GracefulTimeout)
 	defer cancel()
 
 	// first execute the pre-shutdown hook

--- a/mcs/swagger.yml
+++ b/mcs/swagger.yml
@@ -639,3 +639,6 @@ definitions:
         minItems: 1
         items:
           $ref: "#/definitions/configurationKV"
+      arn_resource_id:
+        type: string
+        title: Used if configuration is an event notification's target


### PR DESCRIPTION
for event notification configurations now we can define an extra parameter (not required) as an identifier:
it will build the set configuration like e.g.: 
`notify_postgres:test enable=on format=namespace connection_string=sslmode=disable table=bucket host=127.0.0.1 port=5432 username=postgres password=postgres database=db queue_dir= queue_limit=0`
```
{
  "arn_resource_id": "test",
   "key_values": [
        {
            "key": "enable",
            "value": "on"
        },
        {
            "key": "format",
            "value": "namespace"
        },
        {
            "key": "connection_string",
            "value": "sslmode=disable"
        },
       ...
    ]
}
```