### PR TITLE
Setup MCS

### DIFF
--- a/mcs/README.md
+++ b/mcs/README.md
@@ -2,6 +2,67 @@
 
 This is a REST portal server created using [go-swagger](https://github.com/go-swagger/go-swagger)
 
+## Setup
+
+All `mcs` needs is a MinIO user with admin privileges and URL pointing to your MinIO deployment.
+> Note: We don't recommend using MinIO's Operator Credentials
+
+1. Create a user for `mcs` using `mc`. 
+```
+$ set +o history
+$ mc admin user add myminio mcs YOURMCSSECRET
+$ set -o history
+```
+
+2. Create a policy for `mcs`
+
+```
+$ cat > mcsAdmin.json << EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "admin:*"
+      ],
+      "Effect": "Allow",
+      "Sid": ""
+    },
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::*"
+      ],
+      "Sid": ""
+    }
+  ]
+}
+EOF
+$ mc admin policy add myminio mcsAdmin mcsAdmin.json
+```
+
+3. Set the policy for the new `mcs` user
+
+```
+$ mc admin policy set myminio mcsAdmin user=mcs
+```
+
+## Run MCS server
+To run the server:
+
+```
+$ MCS_ACCESS_KEY=mcs \
+MCS_SECRET_KEY=YOURMCSSECRET \
+MCS_MINIO_SERVER=http://localhost:9000 \
+./mcs-server --port=52300
+```
+You can verify that the apis work by doing the request on `localhost:52300/api/v1/...`
+
+# Development
+
 The API handlers are created using a YAML definition located in `swagger.YAML`.
 
 To add new api, the YAML file needs to be updated with all the desired apis using the [Swagger Basic Structure](https://swagger.io/docs/specification/2-0/basic-structure/), this includes paths, parameters, definitions, tags, etc.
@@ -29,11 +90,3 @@ To run tests:
 ```
  go test ./restapi
 ```
-
-## Run MCS server
-To run the server:
-
-```
-./mcs-server --port=52300
-```
-You can verify that the apis work by doing the request on `localhost:52300/api/v1/...`

--- a/mcs/restapi/client-admin.go
+++ b/mcs/restapi/client-admin.go
@@ -232,9 +232,9 @@ func (ac adminClient) setConfigKV(ctx context.Context, kv string) (err error) {
 }
 
 func newMAdminClient() (*madmin.AdminClient, error) {
-	endpoint := "https://play.min.io"
-	accessKeyID := "Q3AM3UQ867SPQQA43P2F"
-	secretAccessKey := "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+	endpoint := getMinIOServer()
+	accessKeyID := getAccessKey()
+	secretAccessKey := getSecretKey()
 
 	adminClient, pErr := NewAdminClient(endpoint, accessKeyID, secretAccessKey)
 	if pErr != nil {

--- a/mcs/restapi/client.go
+++ b/mcs/restapi/client.go
@@ -94,11 +94,10 @@ func (mc minioClient) getBucketPolicy(bucketName string) (string, error) {
 
 // newMinioClient creates a new MinIO client to talk to the server
 func newMinioClient() (*minio.Client, error) {
-	// TODO: abstract this to fetch from different endpoints
-	endpoint := "play.min.io"
-	accessKeyID := "Q3AM3UQ867SPQQA43P2F"
-	secretAccessKey := "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
-	useSSL := true
+	endpoint := getMinIOEndpoint()
+	accessKeyID := getAccessKey()
+	secretAccessKey := getSecretKey()
+	useSSL := getMinIOEndpointSSL()
 
 	// Initialize minio client object.
 	minioClient, err := minio.NewV4(endpoint, accessKeyID, secretAccessKey, useSSL)

--- a/mcs/restapi/config.go
+++ b/mcs/restapi/config.go
@@ -1,0 +1,59 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2020 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package restapi
+
+import (
+	"strings"
+
+	"github.com/minio/minio/pkg/env"
+)
+
+func getAccessKey() string {
+	return env.Get(McsAccessKey, "minioadmin")
+}
+
+func getSecretKey() string {
+	return env.Get(McsSecretKey, "minioadmin")
+}
+
+func getMinIOServer() string {
+	return env.Get(McsMinIOServer, "http://localhost:9000")
+}
+
+func getMinIOEndpoint() string {
+	server := getMinIOServer()
+	if strings.Contains(server, "://") {
+		parts := strings.Split(server, "://")
+		if len(parts) > 1 {
+			server = parts[1]
+		}
+	}
+	return server
+}
+
+func getMinIOEndpointSSL() bool {
+	server := getMinIOServer()
+	if strings.Contains(server, "://") {
+		parts := strings.Split(server, "://")
+		if len(parts) > 1 {
+			if parts[1] == "https" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/mcs/restapi/consts.go
+++ b/mcs/restapi/consts.go
@@ -16,4 +16,9 @@
 
 package restapi
 
-const Version = `0.1.0`
+const (
+	Version        = `0.1.0`
+	McsAccessKey   = "MCS_ACCESS_KEY"
+	McsSecretKey   = "MCS_SECRET_KEY"
+	McsMinIOServer = "MCS_MINIO_SERVER"
+)


### PR DESCRIPTION
Instructions on how to setup MCS added to readme.
Configuration that reads the client config from 3 environment variables, so now if you'd like to start `mcs` and point it to `play` you could do:

```
$ MCS_ACCESS_KEY=Q3AM3UQ867SPQQA43P2F \
MCS_SECRET_KEY=zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG \
MCS_MINIO_SERVER=https://play.min.io \
./mcs-server --port=52300
```