### PR TITLE
k8s endpoint and credentials for m3

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -23,17 +23,25 @@ import (
 	"github.com/minio/minio/pkg/env"
 )
 
+func getK8sToken() string {
+	return env.Get(m3K8sToken, "")
+}
+
+func getK8sAPIServer() string {
+	return env.Get(m3K8sAPIServer, "http://localhost:8001")
+}
+
 // Returns the namespace in which the controller is installed
 func GetNs() string {
 	return "default"
 }
 
 func getKesContainerImage() string {
-	return env.Get(kesImage, "minio/kes:latest")
+	return env.Get(m3KesImage, "minio/kes:latest")
 }
 
 func getKesRunningPort() int {
-	port, err := strconv.Atoi(env.Get(kesPort, "7373"))
+	port, err := strconv.Atoi(env.Get(m3KesPort, "7373"))
 	if err != nil {
 		port = 7373
 	}
@@ -43,7 +51,7 @@ func getKesRunningPort() int {
 func getKesMTlsAuth() string {
 	defaultMode := "verify"
 	var re = regexp.MustCompile(`^[a-z]+$`)
-	authMode := env.Get(kesMTlsAuth, defaultMode)
+	authMode := env.Get(m3KesMTlsAuth, defaultMode)
 	if !re.MatchString(authMode) {
 		authMode = defaultMode
 	}
@@ -53,7 +61,7 @@ func getKesMTlsAuth() string {
 func getKesConfigPath() string {
 	var re = regexp.MustCompile(`^[a-z_/\-\s0-9\.]+$`)
 	defaultPath := "kes-config/server-config.toml"
-	configPath := env.Get(kesConfigPath, defaultPath)
+	configPath := env.Get(m3KesConfigPath, defaultPath)
 	if !re.MatchString(configPath) {
 		configPath = defaultPath
 	}
@@ -61,21 +69,21 @@ func getKesConfigPath() string {
 }
 
 func getKmsAddress() string {
-	return env.Get(kmsAddress, "")
+	return env.Get(m3KmsAddress, "")
 }
 
 func getKmsToken() string {
-	return env.Get(kmsToken, "")
+	return env.Get(m3KmsToken, "")
 }
 
 func getKmsCACertConfigMap() string {
-	return env.Get(KmsCACertConfigMap, "")
+	return env.Get(m3KmsCACertConfigMap, "")
 }
 
 func getKmsCACertFileName() string {
-	return env.Get(KmsCACertFileName, "")
+	return env.Get(m3KmsCACertFileName, "")
 }
 
 func getCACertDefaultMounPath() string {
-	return env.Get(CACertDefaultMountPath, "/usr/local/share/ca-certificates")
+	return env.Get(m3CACertDefaultMountPath, "/usr/local/share/ca-certificates")
 }

--- a/cluster/const.go
+++ b/cluster/const.go
@@ -17,13 +17,15 @@
 package cluster
 
 const (
-	kesImage               = "KES_IMAGE"
-	kesPort                = "KES_PORT"
-	kesMTlsAuth            = "KES_M_TLS_AUTH"
-	kesConfigPath          = "KES_CONFIG_FILE_PATH"
-	KmsCACertConfigMap     = "KMS_CA_CERT_CONFIG_MAP"
-	KmsCACertFileName      = "KMS_CA_CERT_FILE_NAME"
-	CACertDefaultMountPath = "CA_CERT_DEFAULT_MOUNT_PATH"
-	kmsAddress             = "KMS_ADDRESS"
-	kmsToken               = "KMS_TOKEN"
+	m3KesImage               = "M3_KES_IMAGE"
+	m3KesPort                = "M3_KES_PORT"
+	m3KesMTlsAuth            = "M3_KES_M_TLS_AUTH"
+	m3KesConfigPath          = "M3_KES_CONFIG_FILE_PATH"
+	m3KmsCACertConfigMap     = "M3_KMS_CA_CERT_CONFIG_MAP"
+	m3KmsCACertFileName      = "M3_KMS_CA_CERT_FILE_NAME"
+	m3CACertDefaultMountPath = "M3_CA_CERT_DEFAULT_MOUNT_PATH"
+	m3KmsAddress             = "M3_KMS_ADDRESS"
+	m3KmsToken               = "M3_KMS_TOKEN"
+	m3K8sToken               = "M3_K8S_TOKEN"
+	m3K8sAPIServer           = "M3_K8S_API_SERVER"
 )


### PR DESCRIPTION
Allow user to configured k8s connection via env variables.
This is useful when developing in a local environment since we no longer
need to build and deploy a new m3 image each time we change something.

```
export M3_K8S_TOKEN=secret
export M3_K8S_API_SERVER=https://localhost:8001/
./m3 controller
```