### PR TITLE
Set memory size when requesting MinioInstance on tenant creation

### DIFF
--- a/restapi/config.go
+++ b/restapi/config.go
@@ -38,6 +38,10 @@ var TLSPort = "8443"
 // TLSRedirect m3 tls redirect rule
 var TLSRedirect = "off"
 
+// defaultTenantMemorySize default value used
+// when generating minioInstance request
+var defaultTenantMemorySize = "16Gi"
+
 // GetHostname gets m3 hostname set on env variable,
 // default one or defined on run command
 func GetHostname() string {
@@ -68,4 +72,10 @@ func GetSSLPort() int {
 		port = 9443
 	}
 	return port
+}
+
+// getTenantMemorySize Memory size value to be used when generating the
+// MinioInstance request
+func getTenantMemorySize() string {
+	return env.Get(M3TenantMemorySize, defaultTenantMemorySize)
 }

--- a/restapi/constants.go
+++ b/restapi/constants.go
@@ -23,4 +23,6 @@ const (
 	M3Port        = "M3_PORT"
 	M3TLSHostname = "M3_TLS_HOSTNAME"
 	M3TLSPort     = "M3_TLS_PORT"
+	// M3TenantMemorySize Memory size to be used when creating MinioInstance request
+	M3TenantMemorySize = "M3_TENANT_MEMORY_SIZE"
 )

--- a/restapi/tenants.go
+++ b/restapi/tenants.go
@@ -245,6 +245,11 @@ func getTenantCreatedResponse(params admin_api.CreateTenantParams) error {
 		return err
 	}
 
+	memorySize, err := resource.ParseQuantity(getTenantMemorySize())
+	if err != nil {
+		return err
+	}
+
 	volTemp := corev1.PersistentVolumeClaimSpec{
 		AccessModes: []corev1.PersistentVolumeAccessMode{
 			corev1.ReadWriteOnce,
@@ -252,6 +257,7 @@ func getTenantCreatedResponse(params admin_api.CreateTenantParams) error {
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceStorage: volumeSize,
+				corev1.ResourceMemory:  memorySize,
 			},
 		},
 	}
@@ -266,9 +272,8 @@ func getTenantCreatedResponse(params admin_api.CreateTenantParams) error {
 			Name: *params.Body.Name,
 		},
 		Spec: operator.MinIOInstanceSpec{
-			Image:            minioImage,
-			VolumesPerServer: 1,
-			Mountpath:        "/export",
+			Image:     minioImage,
+			Mountpath: "/export",
 			CredsSecret: &corev1.LocalObjectReference{
 				Name: secretName,
 			},
@@ -327,7 +332,8 @@ func getTenantCreatedResponse(params admin_api.CreateTenantParams) error {
 		}
 	}
 
-	// Set Volumes Per Server if provided
+	// Set Volumes Per Server if provided, default 1
+	minInst.Spec.VolumesPerServer = 1
 	if params.Body.VolumesPerServer > 0 {
 		minInst.Spec.VolumesPerServer = int(params.Body.VolumesPerServer)
 	}


### PR DESCRIPTION
Memory size is now set to 16Gi by default or can be changed using `M3_TENANT_MEMORY_SIZE` env variable.
To test this you need to create a new tenant and when getting the minioinstances on your k8s env the description of the minioInstance should have the request like e.g.:
```
"resources": {
                    "requests": {
                        "memory": "16Gi",
                        "storage": "1Gi"
                    }
                },
```